### PR TITLE
Adding encryption feature to CloudBread v2

### DIFF
--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -286,7 +286,13 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
+    <Compile Include="Models\AddMemberItemPurchase.cs" />
+    <Compile Include="Models\ComSelGiftDepository.cs" />
+    <Compile Include="Models\ComSelItemList1.cs" />
+    <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
+    <Compile Include="Models\RowcountResult.cs" />
+    <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -317,6 +317,7 @@
     <Compile Include="Models\UdtCouponMember.cs" />
     <Compile Include="Models\UdtGameEventMemberToItem.cs" />
     <Compile Include="Models\UdtMemberGameInfoStage.cs" />
+    <Compile Include="Models\UdtMoveGift.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -314,6 +314,7 @@
     <Compile Include="Models\SelMemberItems.cs" />
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Models\SelSendEmailToMember.cs" />
+    <Compile Include="Models\UdtCouponMember.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -307,6 +307,7 @@
     <Compile Include="Models\SelGameEvents.cs" />
     <Compile Include="Models\SelGiftItemToMe.cs" />
     <Compile Include="Models\SelItem1.cs" />
+    <Compile Include="Models\SelItemListAll.cs" />
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -311,6 +311,7 @@
     <Compile Include="Models\SelLoginIDDupeCheck.cs" />
     <Compile Include="Models\SelLoginInfo.cs" />
     <Compile Include="Models\SelMemberGameInfoStages.cs" />
+    <Compile Include="Models\SelMemberItems.cs" />
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -290,6 +290,7 @@
     <Compile Include="Models\ComSelGiftDepository.cs" />
     <Compile Include="Models\ComSelItemList1.cs" />
     <Compile Include="Models\ComSelMember.cs" />
+    <Compile Include="Models\ComSelMemberGameInfoes.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -306,6 +306,7 @@
     <Compile Include="Models\RowcountResult.cs" />
     <Compile Include="Models\SelGameEvents.cs" />
     <Compile Include="Models\SelGiftItemToMe.cs" />
+    <Compile Include="Models\SelItem1.cs" />
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -291,6 +291,7 @@
     <Compile Include="Models\ComSelItemList1.cs" />
     <Compile Include="Models\ComSelMember.cs" />
     <Compile Include="Models\ComSelMemberGameInfoes.cs" />
+    <Compile Include="Models\ComSelMemberGameInfoStages.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -287,6 +287,7 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Models\AddMemberItemPurchase.cs" />
+    <Compile Include="Models\AddUseMemberItem.cs" />
     <Compile Include="Models\ComSelGiftDepository.cs" />
     <Compile Include="Models\ComSelItemList1.cs" />
     <Compile Include="Models\ComSelMember.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -316,6 +316,7 @@
     <Compile Include="Models\SelSendEmailToMember.cs" />
     <Compile Include="Models\UdtCouponMember.cs" />
     <Compile Include="Models\UdtGameEventMemberToItem.cs" />
+    <Compile Include="Models\UdtMemberGameInfoStage.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -295,6 +295,7 @@
     <Compile Include="Models\ComSelMemberItem.cs" />
     <Compile Include="Models\ComSelMemberItemPurchase.cs" />
     <Compile Include="Models\ComUdtGiftDepository.cs" />
+    <Compile Include="Models\COMUdtMember.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -299,6 +299,7 @@
     <Compile Include="Models\ComUdtMemberGameInfoes.cs" />
     <Compile Include="Models\ComUdtMemberGameInfoStages.cs" />
     <Compile Include="Models\ComUdtMemberItem.cs" />
+    <Compile Include="Models\ComUdtMemberItemPurchase.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -305,6 +305,7 @@
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />
     <Compile Include="Models\SelGameEvents.cs" />
+    <Compile Include="Models\SelGiftItemToMe.cs" />
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -301,6 +301,7 @@
     <Compile Include="Models\ComUdtMemberItem.cs" />
     <Compile Include="Models\ComUdtMemberItemPurchase.cs" />
     <Compile Include="Models\EncryptedData.cs" />
+    <Compile Include="Models\InsRegMember.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />
     <Compile Include="Models\SelNotices.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -289,6 +289,7 @@
     <Compile Include="Models\AddMemberItemPurchase.cs" />
     <Compile Include="Models\ComSelGiftDepository.cs" />
     <Compile Include="Models\ComSelItemList1.cs" />
+    <Compile Include="Models\ComSelMember.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -293,6 +293,7 @@
     <Compile Include="Models\ComSelMemberGameInfoes.cs" />
     <Compile Include="Models\ComSelMemberGameInfoStages.cs" />
     <Compile Include="Models\ComSelMemberItem.cs" />
+    <Compile Include="Models\ComSelMemberItemPurchase.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -318,6 +318,7 @@
     <Compile Include="Models\UdtGameEventMemberToItem.cs" />
     <Compile Include="Models\UdtMemberGameInfoStage.cs" />
     <Compile Include="Models\UdtMoveGift.cs" />
+    <Compile Include="Models\UdtReturnItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -288,6 +288,7 @@
     </Compile>
     <Compile Include="Models\AddMemberItemPurchase.cs" />
     <Compile Include="Models\AddUseMemberItem.cs" />
+    <Compile Include="Models\ComInsMemberItemPurchase.cs" />
     <Compile Include="Models\ComSelGiftDepository.cs" />
     <Compile Include="Models\ComSelItemList1.cs" />
     <Compile Include="Models\ComSelMember.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -297,6 +297,7 @@
     <Compile Include="Models\ComUdtGiftDepository.cs" />
     <Compile Include="Models\COMUdtMember.cs" />
     <Compile Include="Models\ComUdtMemberGameInfoes.cs" />
+    <Compile Include="Models\ComUdtMemberGameInfoStages.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -319,6 +319,7 @@
     <Compile Include="Models\UdtMemberGameInfoStage.cs" />
     <Compile Include="Models\UdtMoveGift.cs" />
     <Compile Include="Models\UdtReturnItem.cs" />
+    <Compile Include="Models\UdtSendGift.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -296,6 +296,7 @@
     <Compile Include="Models\ComSelMemberItemPurchase.cs" />
     <Compile Include="Models\ComUdtGiftDepository.cs" />
     <Compile Include="Models\COMUdtMember.cs" />
+    <Compile Include="Models\ComUdtMemberGameInfoes.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -315,6 +315,7 @@
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Models\SelSendEmailToMember.cs" />
     <Compile Include="Models\UdtCouponMember.cs" />
+    <Compile Include="Models\UdtGameEventMemberToItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -309,6 +309,7 @@
     <Compile Include="Models\SelItem1.cs" />
     <Compile Include="Models\SelItemListAll.cs" />
     <Compile Include="Models\SelLoginIDDupeCheck.cs" />
+    <Compile Include="Models\SelLoginInfo.cs" />
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -308,6 +308,7 @@
     <Compile Include="Models\SelGiftItemToMe.cs" />
     <Compile Include="Models\SelItem1.cs" />
     <Compile Include="Models\SelItemListAll.cs" />
+    <Compile Include="Models\SelLoginIDDupeCheck.cs" />
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -298,6 +298,7 @@
     <Compile Include="Models\COMUdtMember.cs" />
     <Compile Include="Models\ComUdtMemberGameInfoes.cs" />
     <Compile Include="Models\ComUdtMemberGameInfoStages.cs" />
+    <Compile Include="Models\ComUdtMemberItem.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -313,6 +313,7 @@
     <Compile Include="Models\SelMemberGameInfoStages.cs" />
     <Compile Include="Models\SelMemberItems.cs" />
     <Compile Include="Models\SelNotices.cs" />
+    <Compile Include="Models\SelSendEmailToMember.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
   </ItemGroup>

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -292,6 +292,7 @@
     <Compile Include="Models\ComSelMember.cs" />
     <Compile Include="Models\ComSelMemberGameInfoes.cs" />
     <Compile Include="Models\ComSelMemberGameInfoStages.cs" />
+    <Compile Include="Models\ComSelMemberItem.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -289,6 +289,7 @@
     <Compile Include="Models\AddMemberItemPurchase.cs" />
     <Compile Include="Models\AddUseMemberItem.cs" />
     <Compile Include="Models\ComInsMemberItemPurchase.cs" />
+    <Compile Include="Models\ComSelCoupon.cs" />
     <Compile Include="Models\ComSelGiftDepository.cs" />
     <Compile Include="Models\ComSelItemList1.cs" />
     <Compile Include="Models\ComSelMember.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -310,6 +310,7 @@
     <Compile Include="Models\SelItemListAll.cs" />
     <Compile Include="Models\SelLoginIDDupeCheck.cs" />
     <Compile Include="Models\SelLoginInfo.cs" />
+    <Compile Include="Models\SelMemberGameInfoStages.cs" />
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -304,6 +304,7 @@
     <Compile Include="Models\InsRegMember.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />
+    <Compile Include="Models\SelGameEvents.cs" />
     <Compile Include="Models\SelNotices.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />

--- a/CloudBread.csproj
+++ b/CloudBread.csproj
@@ -294,6 +294,7 @@
     <Compile Include="Models\ComSelMemberGameInfoStages.cs" />
     <Compile Include="Models\ComSelMemberItem.cs" />
     <Compile Include="Models\ComSelMemberItemPurchase.cs" />
+    <Compile Include="Models\ComUdtGiftDepository.cs" />
     <Compile Include="Models\EncryptedData.cs" />
     <Compile Include="Models\MobileServiceContext.cs" />
     <Compile Include="Models\RowcountResult.cs" />

--- a/Controllers/CBAddMemberItemPurchaseController.cs
+++ b/Controllers/CBAddMemberItemPurchaseController.cs
@@ -33,102 +33,42 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBAddMemberItemPurchaseController : ApiController
     {
-        
-        public class InputParams
+        public HttpResponseMessage Post(AddMemberItemPurchaseInputParams p)
         {
-            public string InsertORUpdate { get; set; }
-            public string MemberItemID_MemberItems { get; set; }
-            public string MemberID_MemberItems { get; set; }
-            public string ItemListID_MemberItems { get; set; }
-            public string ItemCount_MemberItems { get; set; }
-            public string ItemStatus_MemberItems { get; set; }
-            public string sCol1_MemberItems { get; set; }
-            public string sCol2_MemberItems { get; set; }
-            public string sCol3_MemberItems { get; set; }
-            public string sCol4_MemberItems { get; set; }
-            public string sCol5_MemberItems { get; set; }
-            public string sCol6_MemberItems { get; set; }
-            public string sCol7_MemberItems { get; set; }
-            public string sCol8_MemberItems { get; set; }
-            public string sCol9_MemberItems { get; set; }
-            public string sCol10_MemberItems { get; set; }
-            public string MemberID_MemberItemPurchases { get; set; }
-            public string ItemListID_MemberItemPurchases { get; set; }
-            public string PurchaseQuantity_MemberItemPurchases { get; set; }
-            public string PurchasePrice_MemberItemPurchases { get; set; }
-            public string PGinfo1_MemberItemPurchases { get; set; }
-            public string PGinfo2_MemberItemPurchases { get; set; }
-            public string PGinfo3_MemberItemPurchases { get; set; }
-            public string PGinfo4_MemberItemPurchases { get; set; }
-            public string PGinfo5_MemberItemPurchases { get; set; }
-            public string PurchaseDeviceID_MemberItemPurchases { get; set; }
-            public string PurchaseDeviceIPAddress_MemberItemPurchases { get; set; }
-            public string PurchaseDeviceMACAddress_MemberItemPurchases { get; set; }
-            public string PurchaseDT_MemberItemPurchases { get; set; }
-            public string PurchaseCancelYN_MemberItemPurchases { get; set; }
-            public string PurchaseCancelDT_MemberItemPurchases { get; set; }
-            public string PurchaseCancelingStatus_MemberItemPurchases { get; set; }
-            public string PurchaseCancelReturnedAmount_MemberItemPurchases { get; set; }
-            public string PurchaseCancelDeviceID_MemberItemPurchases { get; set; }
-            public string PurchaseCancelDeviceIPAddress_MemberItemPurchases { get; set; }
-            public string PurchaseCancelDeviceMACAddress_MemberItemPurchases { get; set; }
-            public string sCol1_MemberItemPurchases { get; set; }
-            public string sCol2_MemberItemPurchases { get; set; }
-            public string sCol3_MemberItemPurchases { get; set; }
-            public string sCol4_MemberItemPurchases { get; set; }
-            public string sCol5_MemberItemPurchases { get; set; }
-            public string sCol6_MemberItemPurchases { get; set; }
-            public string sCol7_MemberItemPurchases { get; set; }
-            public string sCol8_MemberItemPurchases { get; set; }
-            public string sCol9_MemberItemPurchases { get; set; }
-            public string sCol10_MemberItemPurchases { get; set; }
-            public string MemberID_MemberGameInfoes { get; set; }
-            public string Level_MemberGameInfoes { get; set; }
-            public string Exps_MemberGameInfoes { get; set; }
-            public string Points_MemberGameInfoes { get; set; }
-            public string UserSTAT1_MemberGameInfoes { get; set; }
-            public string UserSTAT2_MemberGameInfoes { get; set; }
-            public string UserSTAT3_MemberGameInfoes { get; set; }
-            public string UserSTAT4_MemberGameInfoes { get; set; }
-            public string UserSTAT5_MemberGameInfoes { get; set; }
-            public string UserSTAT6_MemberGameInfoes { get; set; }
-            public string UserSTAT7_MemberGameInfoes { get; set; }
-            public string UserSTAT8_MemberGameInfoes { get; set; }
-            public string UserSTAT9_MemberGameInfoes { get; set; }
-            public string UserSTAT10_MemberGameInfoes { get; set; }
-            public string sCol1_MemberGameInfoes { get; set; }
-            public string sCol2_MemberGameInfoes { get; set; }
-            public string sCol3_MemberGameInfoes { get; set; }
-            public string sCol4_MemberGameInfoes { get; set; }
-            public string sCol5_MemberGameInfoes { get; set; }
-            public string sCol6_MemberGameInfoes { get; set; }
-            public string sCol7_MemberGameInfoes { get; set; }
-            public string sCol8_MemberGameInfoes { get; set; }
-            public string sCol9_MemberGameInfoes { get; set; }
-            public string sCol10_MemberGameInfoes { get; set; }	
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<AddMemberItemPurchaseInputParams>(decrypted);
 
-
-        }
-
-        public string Post(InputParams p)
-        {
-            string result = "";
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID_MemberGameInfoes, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID_MemberGameInfoes, this.User as ClaimsPrincipal);
             p.MemberID_MemberGameInfoes = sid;
             p.MemberID_MemberItemPurchases = sid;
             p.MemberID_MemberItems = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+            RowcountResult rowCountResult = new RowcountResult();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -223,7 +163,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowCountResult.result = dreader[0].ToString();
                             }
                             dreader.Close();
                         }
@@ -236,7 +176,24 @@ namespace CloudBread.Controllers
                         logMessage.Message = jsonParam;
                         Logging.RunLog(logMessage);
 
-                        return result;
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowCountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
+
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowCountResult);
+                        return response;
                     }
 
                 }

--- a/Controllers/CBComInsMemberItemPurchaseControllerController.cs
+++ b/Controllers/CBComInsMemberItemPurchaseControllerController.cs
@@ -30,59 +30,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComInsMemberItemPurchaseController : ApiController
     {
-        public class InputParams
+        public HttpResponseMessage Post(ComInsMemberItemPurchaseInputParams p)
         {
-            public string MemberItemPurchaseID { get; set; }
-            public string MemberID { get; set; }
-            public string ItemListID { get; set; }
-            public string PurchaseQuantity { get; set; }
-            public string PurchasePrice { get; set; }
-            public string PGinfo1 { get; set; }
-            public string PGinfo2 { get; set; }
-            public string PGinfo3 { get; set; }
-            public string PGinfo4 { get; set; }
-            public string PGinfo5 { get; set; }
-            public string PurchaseDeviceID { get; set; }
-            public string PurchaseDeviceIPAddress { get; set; }
-            public string PurchaseDeviceMACAddress { get; set; }
-            public string PurchaseDT { get; set; }
-            public string PurchaseCancelYN { get; set; }
-            public string PurchaseCancelDT { get; set; }
-            public string PurchaseCancelingStatus { get; set; }
-            public string PurchaseCancelReturnedAmount { get; set; }
-            public string PurchaseCancelDeviceID { get; set; }
-            public string PurchaseCancelDeviceIPAddress { get; set; }
-            public string PurchaseCancelDeviceMACAddress { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
-
-        }
-
-        public string Post(InputParams p)
-        {
-            string result = "";
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComInsMemberItemPurchaseInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
+            RowcountResult rowcountResult = new RowcountResult();
 
             try
             {
@@ -99,7 +80,6 @@ namespace CloudBread.Controllers
                 {
                     using (SqlCommand command = new SqlCommand("uspComInsMemberItemPurchase", connection))
                     {
-
                         command.CommandType = CommandType.StoredProcedure;
                         command.Parameters.Add("@MemberItemPurchaseID", SqlDbType.NVarChar, -1).Value = p.MemberItemPurchaseID;
                         command.Parameters.Add("@MemberID", SqlDbType.NVarChar, -1).Value = p.MemberID;
@@ -138,7 +118,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowcountResult.result = dreader[0].ToString();
                             }
                             dreader.Close();
                         }
@@ -151,9 +131,25 @@ namespace CloudBread.Controllers
                         logMessage.Message = jsonParam;
                         Logging.RunLog(logMessage);
 
-                        return result;
-                    }
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowcountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
 
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
+                        return response;
+                    }
                 }
             }
 
@@ -170,6 +166,5 @@ namespace CloudBread.Controllers
                 throw;
             }
         }
-
     }
 }

--- a/Controllers/CBComSelItemList1Controller.cs
+++ b/Controllers/CBComSelItemList1Controller.cs
@@ -31,53 +31,41 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComSelItemList1Controller : ApiController
     {
-        
-        public class InputParams {
-            public string MemberID;     // log purpose
-            public string ItemListID;
-        }
-
-        public class Model
+        public HttpResponseMessage Post(ComSelItemList1InputParams p)
         {
-            public string ItemListID { get; set; }
-            public string ItemName { get; set; }
-            public string ItemDescription { get; set; }
-            public string ItemPrice { get; set; }
-            public string ItemSellPrice { get; set; }
-            public string ItemCategory1 { get; set; }
-            public string ItemCategory2 { get; set; }
-            public string ItemCategory3 { get; set; }
-            //public string IteamCreateAdminID { get; set; }
-            //public string IteamUpdateAdminID { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
-        }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComSelItemList1InputParams>(decrypted);
 
-        public List<Model> Post(InputParams p)
-        {
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
+
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<ComSelItemList1Model> result = new List<ComSelItemList1Model>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -95,7 +83,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                ComSelItemList1Model workItem = new ComSelItemList1Model()
                                 {
                                     ItemListID = dreader[0].ToString(),
                                     ItemName = dreader[1].ToString(),
@@ -105,8 +93,6 @@ namespace CloudBread.Controllers
                                     ItemCategory1 = dreader[5].ToString(),
                                     ItemCategory2 = dreader[6].ToString(),
                                     ItemCategory3 = dreader[7].ToString(),
-                                    //IteamCreateAdminID = dreader[8].ToString(),
-                                    //IteamUpdateAdminID = dreader[9].ToString(),
                                     sCol1 = dreader[8].ToString(),
                                     sCol2 = dreader[9].ToString(),
                                     sCol3 = dreader[10].ToString(),
@@ -124,7 +110,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 

--- a/Controllers/CBComSelMemberController.cs
+++ b/Controllers/CBComSelMemberController.cs
@@ -29,70 +29,41 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComSelMemberController : ApiController
     {
-        
-        public class InputParams { 
-            public string memberID;
-        }
-
-        public class Model
+        public HttpResponseMessage Post(ComSelMemberInputParams p)
         {
-            public string MemberID { get; set; }
-            public string MemberPWD { get; set; }
-            public string EmailAddress { get; set; }
-            public string EmailConfirmedYN { get; set; }
-            public string PhoneNumber1 { get; set; }
-            public string PhoneNumber2 { get; set; }
-            public string PINumber { get; set; }
-            public string Name1 { get; set; }
-            public string Name2 { get; set; }
-            public string Name3 { get; set; }
-            public string DOB { get; set; }
-            public string RecommenderID { get; set; }
-            public string MemberGroup { get; set; }
-            public string LastDeviceID { get; set; }
-            public string LastIPaddress { get; set; }
-            public string LastLoginDT { get; set; }
-            public string LastLogoutDT { get; set; }
-            public string LastMACAddress { get; set; }
-            public string AccountBlockYN { get; set; }
-            public string AccountBlockEndDT { get; set; }
-            public string AnonymousYN { get; set; }
-            public string _3rdAuthProvider { get; set; }
-            public string _3rdAuthID { get; set; }
-            public string _3rdAuthParam { get; set; }
-            public string PushNotificationID { get; set; }
-            public string PushNotificationProvider { get; set; }
-            public string PushNotificationGroup { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComSelMemberInputParams>(decrypted);
 
-        }
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
-        public List<Model> Post(InputParams p)
-        {
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.memberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.memberID, this.User as ClaimsPrincipal);
             p.memberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<ComSelMemberModel> result = new List<ComSelMemberModel>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -110,7 +81,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                ComSelMemberModel workItem = new ComSelMemberModel()
                                 {
                                     MemberID = dreader[0].ToString(),
                                     MemberPWD = dreader[1].ToString(),
@@ -159,7 +130,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 

--- a/Controllers/CBComSelMemberGameInfoStagesController.cs
+++ b/Controllers/CBComSelMemberGameInfoStagesController.cs
@@ -30,61 +30,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComSelMemberGameInfoStagesController : ApiController
     {
-
-        public class InputParams {
-            public string MemberID { get; set; }    // log purpose
-            public string MemberGameInfoStageID { get; set; }
-        }
-
-        public class Model
+        public HttpResponseMessage Post(ComSelMemberGameInfoStagesInputParams p)
         {
-            public string MemberGameInfoStageID { get; set; }
-            public string MemberID { get; set; }
-            public string StageName { get; set; }
-            public string StageStatus { get; set; }
-            public string Category1 { get; set; }
-            public string Category2 { get; set; }
-            public string Category3 { get; set; }
-            public string Mission1 { get; set; }
-            public string Mission2 { get; set; }
-            public string Mission3 { get; set; }
-            public string Mission4 { get; set; }
-            public string Mission5 { get; set; }
-            public string Points { get; set; }
-            public string StageStat1 { get; set; }
-            public string StageStat2 { get; set; }
-            public string StageStat3 { get; set; }
-            public string StageStat4 { get; set; }
-            public string StageStat5 { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
-        }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComSelMemberGameInfoStagesInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
-        public List<Model> Post(InputParams p)
-        {
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<ComSelMemberGameInfoStagesModel> result = new List<ComSelMemberGameInfoStagesModel>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -103,7 +82,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                ComSelMemberGameInfoStagesModel workItem = new ComSelMemberGameInfoStagesModel()
                                 {
                                     MemberGameInfoStageID = dreader[0].ToString(),
                                     MemberID = dreader[1].ToString(),
@@ -140,7 +119,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 

--- a/Controllers/CBComSelMemberGameInfoesController.cs
+++ b/Controllers/CBComSelMemberGameInfoesController.cs
@@ -30,55 +30,41 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComSelMemberGameInfoesController : ApiController
     {
-        
-        public class InputParams { public string MemberID;}
-
-        public class Model
+        public HttpResponseMessage Post(ComSelMemberGameInfoesInputParams p)
         {
-            public string MemberID { get; set; }
-            public string Level { get; set; }
-            public string Exps { get; set; }
-            public string Points { get; set; }
-            public string UserSTAT1 { get; set; }
-            public string UserSTAT2 { get; set; }
-            public string UserSTAT3 { get; set; }
-            public string UserSTAT4 { get; set; }
-            public string UserSTAT5 { get; set; }
-            public string UserSTAT6 { get; set; }
-            public string UserSTAT7 { get; set; }
-            public string UserSTAT8 { get; set; }
-            public string UserSTAT9 { get; set; }
-            public string UserSTAT10 { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComSelMemberGameInfoesInputParams>(decrypted);
 
-        }
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
-        public List<Model> Post(InputParams p)
-        {
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<ComSelMemberGameInfoesModel> result = new List<ComSelMemberGameInfoesModel>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -96,7 +82,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                ComSelMemberGameInfoesModel workItem = new ComSelMemberGameInfoesModel()
                                 {
                                     MemberID = dreader[0].ToString(),
                                     Level = dreader[1].ToString(),
@@ -130,7 +116,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 

--- a/Controllers/CBComSelMemberItemController.cs
+++ b/Controllers/CBComSelMemberItemController.cs
@@ -30,47 +30,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComSelMemberItemController : ApiController
     {
-        public class InputParams {
-            public string MemberID;     // log purpose
-            public string MemberItemID;
-        }
-
-        public class Model
+        public HttpResponseMessage Post(ComSelMemberItemInputParams p)
         {
-            public string MemberItemID { get; set; }
-            public string MemberID { get; set; }
-            public string ItemListID { get; set; }
-            public string ItemCount { get; set; }
-            public string ItemStatus { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
-        }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComSelMemberItemInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
-        public List<Model> Post(InputParams p)
-        {
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<ComSelMemberItemModel> result = new List<ComSelMemberItemModel>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -89,7 +82,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                ComSelMemberItemModel workItem = new ComSelMemberItemModel()
                                 {
                                     MemberItemID = dreader[0].ToString(),
                                     MemberID = dreader[1].ToString(),
@@ -113,7 +106,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 

--- a/Controllers/CBComSelMemberItemPurchaseController.cs
+++ b/Controllers/CBComSelMemberItemPurchaseController.cs
@@ -30,65 +30,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComSelMemberItemPurchaseController : ApiController
     {
-        
-        public class InputParams {
-            public string MemberID;     // log purpose
-            public string MemberItemPurchaseID;
-        }
-
-        public class Model
+        public HttpResponseMessage Post(ComSelMemberItemPurchaseInputParams p)
         {
-            public string MemberItemPurchaseID { get; set; }
-            public string MemberID { get; set; }
-            public string ItemListID { get; set; }
-            public string PurchaseQuantity { get; set; }
-            public string PurchasePrice { get; set; }
-            public string PGinfo1 { get; set; }
-            public string PGinfo2 { get; set; }
-            public string PGinfo3 { get; set; }
-            public string PGinfo4 { get; set; }
-            public string PGinfo5 { get; set; }
-            public string PurchaseDeviceID { get; set; }
-            public string PurchaseDeviceIPAddress { get; set; }
-            public string PurchaseDeviceMACAddress { get; set; }
-            public string PurchaseDT { get; set; }
-            public string PurchaseCancelYN { get; set; }
-            public string PurchaseCancelDT { get; set; }
-            public string PurchaseCancelingStatus { get; set; }
-            public string PurchaseCancelReturnedAmount { get; set; }
-            public string PurchaseCancelDeviceID { get; set; }
-            public string PurchaseCancelDeviceIPAddress { get; set; }
-            public string PurchaseCancelDeviceMACAddress { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComSelMemberItemPurchaseInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
-        }
-
-        public List<Model> Post(InputParams p)
-        {
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<ComSelMemberItemPurchaseModel> result = new List<ComSelMemberItemPurchaseModel>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -107,7 +82,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                ComSelMemberItemPurchaseModel workItem = new ComSelMemberItemPurchaseModel()
                                 {
                                     MemberItemPurchaseID = dreader[0].ToString(),
                                     MemberID = dreader[1].ToString(),
@@ -148,7 +123,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 

--- a/Controllers/CBComUdtGiftDepositoryController.cs
+++ b/Controllers/CBComUdtGiftDepositoryController.cs
@@ -30,45 +30,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComUdtGiftDepositoryController : ApiController
     {
-        
-        public class InputParams
+        public HttpResponseMessage Post(ComUdtGiftDepositoryInputParams p)
         {
-            public string MemberID; 
-            public string GiftDepositoryID { get; set; }
-            public string ItemListID { get; set; }
-            public string ItemCount { get; set; }
-            public string FromMemberID { get; set; }
-            public string ToMemberID { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
-
-        }
-
-        public string Post(InputParams p)
-        {
-            string result = "";
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComUdtGiftDepositoryInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+
+            RowcountResult rowcountResult = new RowcountResult();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -107,7 +102,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowcountResult.result = dreader[0].ToString();
                             }
                             dreader.Close();
                         }
@@ -120,7 +115,25 @@ namespace CloudBread.Controllers
                         logMessage.Message = jsonParam;
                         Logging.RunLog(logMessage);
 
-                        return result;
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowcountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
+
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
+                        return response;
+
                     }
 
                 }

--- a/Controllers/CBComUdtMemberGameInfoStagesController.cs
+++ b/Controllers/CBComUdtMemberGameInfoStagesController.cs
@@ -30,56 +30,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComUdtMemberGameInfoStagesController : ApiController
     {
-        public class InputParams
+        public HttpResponseMessage Post(ComUdtMemberGameInfoStagesInputParams p)
         {
-            public string MemberGameInfoStageID { get; set; }
-            public string MemberID { get; set; }
-            public string StageName { get; set; }
-            public string StageStatus { get; set; }
-            public string Category1 { get; set; }
-            public string Category2 { get; set; }
-            public string Category3 { get; set; }
-            public string Mission1 { get; set; }
-            public string Mission2 { get; set; }
-            public string Mission3 { get; set; }
-            public string Mission4 { get; set; }
-            public string Mission5 { get; set; }
-            public string Points { get; set; }
-            public string StageStat1 { get; set; }
-            public string StageStat2 { get; set; }
-            public string StageStat3 { get; set; }
-            public string StageStat4 { get; set; }
-            public string StageStat5 { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComUdtMemberGameInfoStagesInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
-        }
-
-        public string Post(InputParams p)
-        {
-            string result = "";
-            
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
+            RowcountResult rowcountResult = new RowcountResult();
 
             try
             {
@@ -131,7 +115,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowcountResult.result = dreader[0].ToString();
                             }
                             dreader.Close();
                         }
@@ -144,7 +128,24 @@ namespace CloudBread.Controllers
                         logMessage.Message = jsonParam;
                         Logging.RunLog(logMessage);
 
-                        return result;
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowcountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
+
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
+                        return response;
                     }
 
                 }

--- a/Controllers/CBComUdtMemberGameInfoesController.cs
+++ b/Controllers/CBComUdtMemberGameInfoesController.cs
@@ -30,53 +30,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComUdtMemberGameInfoesController : ApiController
     {
-        
-        public class InputParams
+        public HttpResponseMessage Post(ComUdtMemberGameInfoesInputParams p)
         {
-            public string MemberID { get; set; }
-            public string Level { get; set; }
-            public string Exps { get; set; }
-            public string Points { get; set; }
-            public string UserSTAT1 { get; set; }
-            public string UserSTAT2 { get; set; }
-            public string UserSTAT3 { get; set; }
-            public string UserSTAT4 { get; set; }
-            public string UserSTAT5 { get; set; }
-            public string UserSTAT6 { get; set; }
-            public string UserSTAT7 { get; set; }
-            public string UserSTAT8 { get; set; }
-            public string UserSTAT9 { get; set; }
-            public string UserSTAT10 { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
-
-        }
-
-        public string Post(InputParams p)
-        {
-            string result = "";
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComUdtMemberGameInfoesInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
+            RowcountResult rowcountResult = new RowcountResult();
 
             try
             {
@@ -125,7 +112,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowcountResult.result = dreader[0].ToString();
                             }
                             dreader.Close();
                         }
@@ -138,7 +125,24 @@ namespace CloudBread.Controllers
                         logMessage.Message = jsonParam;
                         Logging.RunLog(logMessage);
 
-                        return result;
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowcountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
+
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
+                        return response;
                     }
 
                 }

--- a/Controllers/CBComUdtMemberItemController.cs
+++ b/Controllers/CBComUdtMemberItemController.cs
@@ -30,42 +30,42 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBComUdtMemberItemController : ApiController
     {
-        public class InputParams
-        {
-            public string MemberItemID { get; set; }
-            public string MemberID { get; set; }
-            public string ItemListID { get; set; }
-            public string ItemCount { get; set; }
-            public string ItemStatus { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
-        }
+        
 
-        public string Post(InputParams p)
+        public HttpResponseMessage Post(ComUdtMemberItemInputParams p)
         {
-            string result = "";
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<ComUdtMemberItemInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
+            RowcountResult rowcountResult = new RowcountResult();
 
             try
             {
@@ -105,7 +105,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowcountResult.result = dreader[0].ToString();
                             }
                             dreader.Close();
                         }
@@ -118,7 +118,24 @@ namespace CloudBread.Controllers
                         logMessage.Message = jsonParam;
                         Logging.RunLog(logMessage);
 
-                        return result;
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowcountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
+
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
+                        return response;
                     }
 
                 }

--- a/Controllers/CBComUdtMemberItemController.cs
+++ b/Controllers/CBComUdtMemberItemController.cs
@@ -37,8 +37,6 @@ namespace CloudBread.Controllers
     [MobileAppController]
     public class CBComUdtMemberItemController : ApiController
     {
-        
-
         public HttpResponseMessage Post(ComUdtMemberItemInputParams p)
         {
             // try decrypt data
@@ -82,7 +80,6 @@ namespace CloudBread.Controllers
                 {
                     using (SqlCommand command = new SqlCommand("uspComUdtMemberItem", connection))
                     {
-
                         command.CommandType = CommandType.StoredProcedure;
                         command.Parameters.Add("@MemberItemID ", SqlDbType.NVarChar, -1).Value = p.MemberItemID;
                         command.Parameters.Add("@MemberID ", SqlDbType.NVarChar, -1).Value = p.MemberID;
@@ -137,7 +134,6 @@ namespace CloudBread.Controllers
                         response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
                         return response;
                     }
-
                 }
             }
 
@@ -154,6 +150,5 @@ namespace CloudBread.Controllers
                 throw;
             }
         }
-
     }
 }

--- a/Controllers/CBInsAnonymousRegMemberController.cs
+++ b/Controllers/CBInsAnonymousRegMemberController.cs
@@ -10,230 +10,230 @@
 * @param members and MemberGameInfoes object
 * @return string value "2" affected rows count
 * @see uspInsAnonymousRegMember SP, BehaviorID : B03
-* @todo change return value to inserted data as json
+* @todo this API is deplicated in v2.1
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Web.Http;
-using Microsoft.Azure.Mobile.Server;
-using Microsoft.Azure.Mobile.Server.Config;
+//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Net;
+//using System.Net.Http;
+//using System.Web.Http;
+//using Microsoft.Azure.Mobile.Server;
+//using Microsoft.Azure.Mobile.Server.Config;
 
-using System.Threading.Tasks;
-using System.Diagnostics;
-using Logger.Logging;
-using CloudBread.globals;
-using CloudBreadLib.BAL.Crypto;
-using System.Data;
-using System.Data.Sql;
-using System.Data.SqlClient;
-using Newtonsoft.Json;
-using CloudBreadAuth;
-using System.Security.Claims;
-using Microsoft.Practices.TransientFaultHandling;
-using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+//using System.Threading.Tasks;
+//using System.Diagnostics;
+//using Logger.Logging;
+//using CloudBread.globals;
+//using CloudBreadLib.BAL.Crypto;
+//using System.Data;
+//using System.Data.Sql;
+//using System.Data.SqlClient;
+//using Newtonsoft.Json;
+//using CloudBreadAuth;
+//using System.Security.Claims;
+//using Microsoft.Practices.TransientFaultHandling;
+//using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
 
-namespace CloudBread.Controllers
-{
-    [MobileAppController]
-    public class CBInsAnonymousRegMemberController : ApiController
-    {
+//namespace CloudBread.Controllers
+//{
+//    [MobileAppController]
+//    public class CBInsAnonymousRegMemberController : ApiController
+//    {
         
-        public class InputParams
-        {
-            public string MembersMemberID { get; set; }
-            public string MembersMemberPWD { get; set; }
-            public string MembersEmailAddress { get; set; }
-            public string MembersEmailConfirmedYN { get; set; }
-            public string MembersPhoneNumber1 { get; set; }
-            public string MembersPhoneNumber2 { get; set; }
-            public string MembersPINumber { get; set; }
-            public string MembersName1 { get; set; }
-            public string MembersName2 { get; set; }
-            public string MembersName3 { get; set; }
-            public string MembersDOB { get; set; }
-            public string MembersRecommenderID { get; set; }
-            public string MembersMemberGroup { get; set; }
-            public string MembersLastDeviceID { get; set; }
-            public string MembersLastIPaddress { get; set; }
-            public string MembersLastLoginDT { get; set; }
-            public string MembersLastLogoutDT { get; set; }
-            public string MembersLastMACAddress { get; set; }
-            public string MembersAccountBlockYN { get; set; }
-            public string MembersAccountBlockEndDT { get; set; }
-            public string MembersAnonymousYN { get; set; }
-            public string Members3rdAuthProvider { get; set; }
-            public string Members3rdAuthID { get; set; }
-            public string Members3rdAuthParam { get; set; }
-            public string MembersPushNotificationID { get; set; }
-            public string MembersPushNotificationProvider { get; set; }
-            public string MembersPushNotificationGroup { get; set; }
-            public string MemberssCol1 { get; set; }
-            public string MemberssCol2 { get; set; }
-            public string MemberssCol3 { get; set; }
-            public string MemberssCol4 { get; set; }
-            public string MemberssCol5 { get; set; }
-            public string MemberssCol6 { get; set; }
-            public string MemberssCol7 { get; set; }
-            public string MemberssCol8 { get; set; }
-            public string MemberssCol9 { get; set; }
-            public string MemberssCol10 { get; set; }
-            public string MembersTimeZoneID { get; set; }
-            public string MemberGameInfoesLevel { get; set; }
-            public string MemberGameInfoesExps { get; set; }
-            public string MemberGameInfoesPoints { get; set; }
-            public string MemberGameInfoesUserSTAT1 { get; set; }
-            public string MemberGameInfoesUserSTAT2 { get; set; }
-            public string MemberGameInfoesUserSTAT3 { get; set; }
-            public string MemberGameInfoesUserSTAT4 { get; set; }
-            public string MemberGameInfoesUserSTAT5 { get; set; }
-            public string MemberGameInfoesUserSTAT6 { get; set; }
-            public string MemberGameInfoesUserSTAT7 { get; set; }
-            public string MemberGameInfoesUserSTAT8 { get; set; }
-            public string MemberGameInfoesUserSTAT9 { get; set; }
-            public string MemberGameInfoesUserSTAT10 { get; set; }
-            public string MemberGameInfoessCol1 { get; set; }
-            public string MemberGameInfoessCol2 { get; set; }
-            public string MemberGameInfoessCol3 { get; set; }
-            public string MemberGameInfoessCol4 { get; set; }
-            public string MemberGameInfoessCol5 { get; set; }
-            public string MemberGameInfoessCol6 { get; set; }
-            public string MemberGameInfoessCol7 { get; set; }
-            public string MemberGameInfoessCol8 { get; set; }
-            public string MemberGameInfoessCol9 { get; set; }
-            public string MemberGameInfoessCol10 { get; set; }
+//        public class InputParams
+//        {
+//            public string MembersMemberID { get; set; }
+//            public string MembersMemberPWD { get; set; }
+//            public string MembersEmailAddress { get; set; }
+//            public string MembersEmailConfirmedYN { get; set; }
+//            public string MembersPhoneNumber1 { get; set; }
+//            public string MembersPhoneNumber2 { get; set; }
+//            public string MembersPINumber { get; set; }
+//            public string MembersName1 { get; set; }
+//            public string MembersName2 { get; set; }
+//            public string MembersName3 { get; set; }
+//            public string MembersDOB { get; set; }
+//            public string MembersRecommenderID { get; set; }
+//            public string MembersMemberGroup { get; set; }
+//            public string MembersLastDeviceID { get; set; }
+//            public string MembersLastIPaddress { get; set; }
+//            public string MembersLastLoginDT { get; set; }
+//            public string MembersLastLogoutDT { get; set; }
+//            public string MembersLastMACAddress { get; set; }
+//            public string MembersAccountBlockYN { get; set; }
+//            public string MembersAccountBlockEndDT { get; set; }
+//            public string MembersAnonymousYN { get; set; }
+//            public string Members3rdAuthProvider { get; set; }
+//            public string Members3rdAuthID { get; set; }
+//            public string Members3rdAuthParam { get; set; }
+//            public string MembersPushNotificationID { get; set; }
+//            public string MembersPushNotificationProvider { get; set; }
+//            public string MembersPushNotificationGroup { get; set; }
+//            public string MemberssCol1 { get; set; }
+//            public string MemberssCol2 { get; set; }
+//            public string MemberssCol3 { get; set; }
+//            public string MemberssCol4 { get; set; }
+//            public string MemberssCol5 { get; set; }
+//            public string MemberssCol6 { get; set; }
+//            public string MemberssCol7 { get; set; }
+//            public string MemberssCol8 { get; set; }
+//            public string MemberssCol9 { get; set; }
+//            public string MemberssCol10 { get; set; }
+//            public string MembersTimeZoneID { get; set; }
+//            public string MemberGameInfoesLevel { get; set; }
+//            public string MemberGameInfoesExps { get; set; }
+//            public string MemberGameInfoesPoints { get; set; }
+//            public string MemberGameInfoesUserSTAT1 { get; set; }
+//            public string MemberGameInfoesUserSTAT2 { get; set; }
+//            public string MemberGameInfoesUserSTAT3 { get; set; }
+//            public string MemberGameInfoesUserSTAT4 { get; set; }
+//            public string MemberGameInfoesUserSTAT5 { get; set; }
+//            public string MemberGameInfoesUserSTAT6 { get; set; }
+//            public string MemberGameInfoesUserSTAT7 { get; set; }
+//            public string MemberGameInfoesUserSTAT8 { get; set; }
+//            public string MemberGameInfoesUserSTAT9 { get; set; }
+//            public string MemberGameInfoesUserSTAT10 { get; set; }
+//            public string MemberGameInfoessCol1 { get; set; }
+//            public string MemberGameInfoessCol2 { get; set; }
+//            public string MemberGameInfoessCol3 { get; set; }
+//            public string MemberGameInfoessCol4 { get; set; }
+//            public string MemberGameInfoessCol5 { get; set; }
+//            public string MemberGameInfoessCol6 { get; set; }
+//            public string MemberGameInfoessCol7 { get; set; }
+//            public string MemberGameInfoessCol8 { get; set; }
+//            public string MemberGameInfoessCol9 { get; set; }
+//            public string MemberGameInfoessCol10 { get; set; }
 
-        }
-        public string Post(InputParams p)
-        {
-            string result = "";
+//        }
+//        public string Post(InputParams p)
+//        {
+//            string result = "";
 
-            // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MembersMemberID, claimsPrincipal);
-            p.MembersMemberID = sid;
+//            // Get the sid or memberID of the current user.
+//            var claimsPrincipal = this.User as ClaimsPrincipal;
+//            string sid = CBAuth.getMemberID(p.MembersMemberID, claimsPrincipal);
+//            p.MembersMemberID = sid;
 
-            Logging.CBLoggers logMessage = new Logging.CBLoggers();
-            string jsonParam = JsonConvert.SerializeObject(p);
+//            Logging.CBLoggers logMessage = new Logging.CBLoggers();
+//            string jsonParam = JsonConvert.SerializeObject(p);
 
-            try
-            {
-                // task start log
-                //logMessage.memberID = p.MembersMemberID;
-                //logMessage.Level = "INFO";
-                //logMessage.Logger = "CBInsAnonymousRegMemberController";
-                //logMessage.Message = jsonParam;
-                //Logging.RunLog(logMessage);
+//            try
+//            {
+//                // task start log
+//                //logMessage.memberID = p.MembersMemberID;
+//                //logMessage.Level = "INFO";
+//                //logMessage.Logger = "CBInsAnonymousRegMemberController";
+//                //logMessage.Message = jsonParam;
+//                //Logging.RunLog(logMessage);
 
-                /// Database connection retry policy
-                RetryPolicy retryPolicy = new RetryPolicy<SqlAzureTransientErrorDetectionStrategy>(globalVal.conRetryCount, TimeSpan.FromSeconds(globalVal.conRetryFromSeconds));
-                using (SqlConnection connection = new SqlConnection(globalVal.DBConnectionString))
-                {
-                    using (SqlCommand command = new SqlCommand("uspInsAnonymousRegMember", connection))
-                    {
-                        command.CommandType = CommandType.StoredProcedure;
-                        command.Parameters.Add("@MembersMemberID", SqlDbType.NVarChar, -1).Value = p.MembersMemberID;
-                        command.Parameters.Add("@MembersMemberPWD", SqlDbType.NVarChar, -1).Value = p.MembersMemberPWD;
-                        command.Parameters.Add("@MembersEmailAddress", SqlDbType.NVarChar, -1).Value = p.MembersEmailAddress;
-                        command.Parameters.Add("@MembersEmailConfirmedYN", SqlDbType.NVarChar, -1).Value = p.MembersEmailConfirmedYN;
-                        command.Parameters.Add("@MembersPhoneNumber1", SqlDbType.NVarChar, -1).Value = p.MembersPhoneNumber1;
-                        command.Parameters.Add("@MembersPhoneNumber2", SqlDbType.NVarChar, -1).Value = p.MembersPhoneNumber2;
-                        command.Parameters.Add("@MembersPINumber", SqlDbType.NVarChar, -1).Value = p.MembersPINumber;
-                        command.Parameters.Add("@MembersName1", SqlDbType.NVarChar, -1).Value = p.MembersName1;
-                        command.Parameters.Add("@MembersName2", SqlDbType.NVarChar, -1).Value = p.MembersName2;
-                        command.Parameters.Add("@MembersName3", SqlDbType.NVarChar, -1).Value = p.MembersName3;
-                        command.Parameters.Add("@MembersDOB", SqlDbType.NVarChar, -1).Value = p.MembersDOB;
-                        command.Parameters.Add("@MembersRecommenderID", SqlDbType.NVarChar, -1).Value = p.MembersRecommenderID;
-                        command.Parameters.Add("@MembersMemberGroup", SqlDbType.NVarChar, -1).Value = p.MembersMemberGroup;
-                        command.Parameters.Add("@MembersLastDeviceID", SqlDbType.NVarChar, -1).Value = p.MembersLastDeviceID;
-                        command.Parameters.Add("@MembersLastIPaddress", SqlDbType.NVarChar, -1).Value = p.MembersLastIPaddress;
-                        command.Parameters.Add("@MembersLastLoginDT", SqlDbType.NVarChar, -1).Value = p.MembersLastLoginDT;
-                        command.Parameters.Add("@MembersLastLogoutDT", SqlDbType.NVarChar, -1).Value = p.MembersLastLogoutDT;
-                        command.Parameters.Add("@MembersLastMACAddress", SqlDbType.NVarChar, -1).Value = p.MembersLastMACAddress;
-                        command.Parameters.Add("@MembersAccountBlockYN", SqlDbType.NVarChar, -1).Value = p.MembersAccountBlockYN;
-                        command.Parameters.Add("@MembersAccountBlockEndDT", SqlDbType.NVarChar, -1).Value = p.MembersAccountBlockEndDT;
-                        command.Parameters.Add("@MembersAnonymousYN", SqlDbType.NVarChar, -1).Value = p.MembersAnonymousYN;
-                        command.Parameters.Add("@Members3rdAuthProvider", SqlDbType.NVarChar, -1).Value = p.Members3rdAuthProvider;
-                        command.Parameters.Add("@Members3rdAuthID", SqlDbType.NVarChar, -1).Value = p.Members3rdAuthID;
-                        command.Parameters.Add("@Members3rdAuthParam", SqlDbType.NVarChar, -1).Value = p.Members3rdAuthParam;
-                        command.Parameters.Add("@MembersPushNotificationID", SqlDbType.NVarChar, -1).Value = p.MembersPushNotificationID;
-                        command.Parameters.Add("@MembersPushNotificationProvider", SqlDbType.NVarChar, -1).Value = p.MembersPushNotificationProvider;
-                        command.Parameters.Add("@MembersPushNotificationGroup", SqlDbType.NVarChar, -1).Value = p.MembersPushNotificationGroup;
-                        command.Parameters.Add("@MemberssCol1", SqlDbType.NVarChar, -1).Value = p.MemberssCol1;
-                        command.Parameters.Add("@MemberssCol2", SqlDbType.NVarChar, -1).Value = p.MemberssCol2;
-                        command.Parameters.Add("@MemberssCol3", SqlDbType.NVarChar, -1).Value = p.MemberssCol3;
-                        command.Parameters.Add("@MemberssCol4", SqlDbType.NVarChar, -1).Value = p.MemberssCol4;
-                        command.Parameters.Add("@MemberssCol5", SqlDbType.NVarChar, -1).Value = p.MemberssCol5;
-                        command.Parameters.Add("@MemberssCol6", SqlDbType.NVarChar, -1).Value = p.MemberssCol6;
-                        command.Parameters.Add("@MemberssCol7", SqlDbType.NVarChar, -1).Value = p.MemberssCol7;
-                        command.Parameters.Add("@MemberssCol8", SqlDbType.NVarChar, -1).Value = p.MemberssCol8;
-                        command.Parameters.Add("@MemberssCol9", SqlDbType.NVarChar, -1).Value = p.MemberssCol9;
-                        command.Parameters.Add("@MemberssCol10", SqlDbType.NVarChar, -1).Value = p.MemberssCol10;
-                        command.Parameters.Add("@MembersTimeZoneID", SqlDbType.NVarChar, -1).Value = p.MembersTimeZoneID;
-                        command.Parameters.Add("@MemberGameInfoesLevel", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesLevel;
-                        command.Parameters.Add("@MemberGameInfoesExps", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesExps;
-                        command.Parameters.Add("@MemberGameInfoesPoints", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesPoints;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT1", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT1;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT2", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT2;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT3", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT3;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT4", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT4;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT5", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT5;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT6", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT6;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT7", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT7;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT8", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT8;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT9", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT9;
-                        command.Parameters.Add("@MemberGameInfoesUserSTAT10", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT10;
-                        command.Parameters.Add("@MemberGameInfoessCol1", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol1;
-                        command.Parameters.Add("@MemberGameInfoessCol2", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol2;
-                        command.Parameters.Add("@MemberGameInfoessCol3", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol3;
-                        command.Parameters.Add("@MemberGameInfoessCol4", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol4;
-                        command.Parameters.Add("@MemberGameInfoessCol5", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol5;
-                        command.Parameters.Add("@MemberGameInfoessCol6", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol6;
-                        command.Parameters.Add("@MemberGameInfoessCol7", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol7;
-                        command.Parameters.Add("@MemberGameInfoessCol8", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol8;
-                        command.Parameters.Add("@MemberGameInfoessCol9", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol9;
-                        command.Parameters.Add("@MemberGameInfoessCol10", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol10;
+//                /// Database connection retry policy
+//                RetryPolicy retryPolicy = new RetryPolicy<SqlAzureTransientErrorDetectionStrategy>(globalVal.conRetryCount, TimeSpan.FromSeconds(globalVal.conRetryFromSeconds));
+//                using (SqlConnection connection = new SqlConnection(globalVal.DBConnectionString))
+//                {
+//                    using (SqlCommand command = new SqlCommand("uspInsAnonymousRegMember", connection))
+//                    {
+//                        command.CommandType = CommandType.StoredProcedure;
+//                        command.Parameters.Add("@MembersMemberID", SqlDbType.NVarChar, -1).Value = p.MembersMemberID;
+//                        command.Parameters.Add("@MembersMemberPWD", SqlDbType.NVarChar, -1).Value = p.MembersMemberPWD;
+//                        command.Parameters.Add("@MembersEmailAddress", SqlDbType.NVarChar, -1).Value = p.MembersEmailAddress;
+//                        command.Parameters.Add("@MembersEmailConfirmedYN", SqlDbType.NVarChar, -1).Value = p.MembersEmailConfirmedYN;
+//                        command.Parameters.Add("@MembersPhoneNumber1", SqlDbType.NVarChar, -1).Value = p.MembersPhoneNumber1;
+//                        command.Parameters.Add("@MembersPhoneNumber2", SqlDbType.NVarChar, -1).Value = p.MembersPhoneNumber2;
+//                        command.Parameters.Add("@MembersPINumber", SqlDbType.NVarChar, -1).Value = p.MembersPINumber;
+//                        command.Parameters.Add("@MembersName1", SqlDbType.NVarChar, -1).Value = p.MembersName1;
+//                        command.Parameters.Add("@MembersName2", SqlDbType.NVarChar, -1).Value = p.MembersName2;
+//                        command.Parameters.Add("@MembersName3", SqlDbType.NVarChar, -1).Value = p.MembersName3;
+//                        command.Parameters.Add("@MembersDOB", SqlDbType.NVarChar, -1).Value = p.MembersDOB;
+//                        command.Parameters.Add("@MembersRecommenderID", SqlDbType.NVarChar, -1).Value = p.MembersRecommenderID;
+//                        command.Parameters.Add("@MembersMemberGroup", SqlDbType.NVarChar, -1).Value = p.MembersMemberGroup;
+//                        command.Parameters.Add("@MembersLastDeviceID", SqlDbType.NVarChar, -1).Value = p.MembersLastDeviceID;
+//                        command.Parameters.Add("@MembersLastIPaddress", SqlDbType.NVarChar, -1).Value = p.MembersLastIPaddress;
+//                        command.Parameters.Add("@MembersLastLoginDT", SqlDbType.NVarChar, -1).Value = p.MembersLastLoginDT;
+//                        command.Parameters.Add("@MembersLastLogoutDT", SqlDbType.NVarChar, -1).Value = p.MembersLastLogoutDT;
+//                        command.Parameters.Add("@MembersLastMACAddress", SqlDbType.NVarChar, -1).Value = p.MembersLastMACAddress;
+//                        command.Parameters.Add("@MembersAccountBlockYN", SqlDbType.NVarChar, -1).Value = p.MembersAccountBlockYN;
+//                        command.Parameters.Add("@MembersAccountBlockEndDT", SqlDbType.NVarChar, -1).Value = p.MembersAccountBlockEndDT;
+//                        command.Parameters.Add("@MembersAnonymousYN", SqlDbType.NVarChar, -1).Value = p.MembersAnonymousYN;
+//                        command.Parameters.Add("@Members3rdAuthProvider", SqlDbType.NVarChar, -1).Value = p.Members3rdAuthProvider;
+//                        command.Parameters.Add("@Members3rdAuthID", SqlDbType.NVarChar, -1).Value = p.Members3rdAuthID;
+//                        command.Parameters.Add("@Members3rdAuthParam", SqlDbType.NVarChar, -1).Value = p.Members3rdAuthParam;
+//                        command.Parameters.Add("@MembersPushNotificationID", SqlDbType.NVarChar, -1).Value = p.MembersPushNotificationID;
+//                        command.Parameters.Add("@MembersPushNotificationProvider", SqlDbType.NVarChar, -1).Value = p.MembersPushNotificationProvider;
+//                        command.Parameters.Add("@MembersPushNotificationGroup", SqlDbType.NVarChar, -1).Value = p.MembersPushNotificationGroup;
+//                        command.Parameters.Add("@MemberssCol1", SqlDbType.NVarChar, -1).Value = p.MemberssCol1;
+//                        command.Parameters.Add("@MemberssCol2", SqlDbType.NVarChar, -1).Value = p.MemberssCol2;
+//                        command.Parameters.Add("@MemberssCol3", SqlDbType.NVarChar, -1).Value = p.MemberssCol3;
+//                        command.Parameters.Add("@MemberssCol4", SqlDbType.NVarChar, -1).Value = p.MemberssCol4;
+//                        command.Parameters.Add("@MemberssCol5", SqlDbType.NVarChar, -1).Value = p.MemberssCol5;
+//                        command.Parameters.Add("@MemberssCol6", SqlDbType.NVarChar, -1).Value = p.MemberssCol6;
+//                        command.Parameters.Add("@MemberssCol7", SqlDbType.NVarChar, -1).Value = p.MemberssCol7;
+//                        command.Parameters.Add("@MemberssCol8", SqlDbType.NVarChar, -1).Value = p.MemberssCol8;
+//                        command.Parameters.Add("@MemberssCol9", SqlDbType.NVarChar, -1).Value = p.MemberssCol9;
+//                        command.Parameters.Add("@MemberssCol10", SqlDbType.NVarChar, -1).Value = p.MemberssCol10;
+//                        command.Parameters.Add("@MembersTimeZoneID", SqlDbType.NVarChar, -1).Value = p.MembersTimeZoneID;
+//                        command.Parameters.Add("@MemberGameInfoesLevel", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesLevel;
+//                        command.Parameters.Add("@MemberGameInfoesExps", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesExps;
+//                        command.Parameters.Add("@MemberGameInfoesPoints", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesPoints;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT1", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT1;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT2", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT2;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT3", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT3;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT4", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT4;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT5", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT5;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT6", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT6;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT7", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT7;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT8", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT8;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT9", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT9;
+//                        command.Parameters.Add("@MemberGameInfoesUserSTAT10", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoesUserSTAT10;
+//                        command.Parameters.Add("@MemberGameInfoessCol1", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol1;
+//                        command.Parameters.Add("@MemberGameInfoessCol2", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol2;
+//                        command.Parameters.Add("@MemberGameInfoessCol3", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol3;
+//                        command.Parameters.Add("@MemberGameInfoessCol4", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol4;
+//                        command.Parameters.Add("@MemberGameInfoessCol5", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol5;
+//                        command.Parameters.Add("@MemberGameInfoessCol6", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol6;
+//                        command.Parameters.Add("@MemberGameInfoessCol7", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol7;
+//                        command.Parameters.Add("@MemberGameInfoessCol8", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol8;
+//                        command.Parameters.Add("@MemberGameInfoessCol9", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol9;
+//                        command.Parameters.Add("@MemberGameInfoessCol10", SqlDbType.NVarChar, -1).Value = p.MemberGameInfoessCol10;
 
-                        connection.OpenWithRetry(retryPolicy);
-                        using (SqlDataReader dreader = command.ExecuteReaderWithRetry(retryPolicy))
-                        {
-                            while (dreader.Read())
-                            {
-                                result = dreader[0].ToString();
-                            }
-                            dreader.Close();
-                        }
-                        connection.Close();
+//                        connection.OpenWithRetry(retryPolicy);
+//                        using (SqlDataReader dreader = command.ExecuteReaderWithRetry(retryPolicy))
+//                        {
+//                            while (dreader.Read())
+//                            {
+//                                result = dreader[0].ToString();
+//                            }
+//                            dreader.Close();
+//                        }
+//                        connection.Close();
 
-                        // task end log
-                        logMessage.memberID = p.MembersMemberID;
-                        logMessage.Level = "INFO";
-                        logMessage.Logger = "CBInsAnonymousRegMemberController";
-                        logMessage.Message = jsonParam;
-                        Logging.RunLog(logMessage);
+//                        // task end log
+//                        logMessage.memberID = p.MembersMemberID;
+//                        logMessage.Level = "INFO";
+//                        logMessage.Logger = "CBInsAnonymousRegMemberController";
+//                        logMessage.Message = jsonParam;
+//                        Logging.RunLog(logMessage);
 
-                        return result;
-                    }
-                }
-            }
+//                        return result;
+//                    }
+//                }
+//            }
 
-            catch (Exception ex)
-            {
-                // error log
-                logMessage.memberID = p.MembersMemberID;
-                logMessage.Level = "ERROR";
-                logMessage.Logger = "CBInsAnonymousRegMemberController";
-                logMessage.Message = jsonParam;
-                logMessage.Exception = ex.ToString();
-                Logging.RunLog(logMessage);
+//            catch (Exception ex)
+//            {
+//                // error log
+//                logMessage.memberID = p.MembersMemberID;
+//                logMessage.Level = "ERROR";
+//                logMessage.Logger = "CBInsAnonymousRegMemberController";
+//                logMessage.Message = jsonParam;
+//                logMessage.Exception = ex.ToString();
+//                Logging.RunLog(logMessage);
 
-                throw;
-            }
-        }
+//                throw;
+//            }
+//        }
         
 
-    }
-}
+//    }
+//}

--- a/Controllers/CBSelGameEventsController.cs
+++ b/Controllers/CBSelGameEventsController.cs
@@ -32,54 +32,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBSelGameEventsController : ApiController
     {
-        
-        public class InputParams { public string MemberID; }
-
-        public class Model
+        public HttpResponseMessage Post(SelGameEventsInputParams p)
         {
-            public string GameEventID { get; set; }
-            public string eventCategory1 { get; set; }
-            public string eventCategory2 { get; set; }
-            public string eventCategory3 { get; set; }
-            public string ItemListID { get; set; }
-            public string ItemCount { get; set; }
-            public string Itemstatus { get; set; }
-            public string TargetGroup { get; set; }
-            public string TargetOS { get; set; }
-            public string TargetDevice { get; set; }
-            public string EventImageLink { get; set; }
-            public string Title { get; set; }
-            public string Content { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<SelGameEventsInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
-        }
-
-        public List<Model> Post(InputParams p)
-        {
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<SelGameEventsModel> result = new List<SelGameEventsModel>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -97,7 +83,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                SelGameEventsModel workItem = new SelGameEventsModel()
                                 {
                                     GameEventID = dreader[0].ToString(),
                                     eventCategory1 = dreader[1].ToString(),
@@ -129,7 +115,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 
@@ -146,6 +150,5 @@ namespace CloudBread.Controllers
                 throw;
             }
         }
-
     }
 }

--- a/Controllers/CBSelGiftItemToMeController.cs
+++ b/Controllers/CBSelGiftItemToMeController.cs
@@ -39,6 +39,21 @@ namespace CloudBread.Controllers
     {
         public HttpResponseMessage Post(SelGiftItemToMeInputParams p)
         {
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<SelGiftItemToMeInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
+
             // Get the sid or memberID of the current user.
             string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;

--- a/Controllers/CBSelGiftItemToMeController.cs
+++ b/Controllers/CBSelGiftItemToMeController.cs
@@ -30,44 +30,25 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBSelGiftItemToMeController : ApiController
     {
-        public class InputParams { public string MemberID;}
-
-        public class Model
-        {
-            public string GiftDepositoryID { get; set; }
-            public string ItemListID { get; set; }
-            public string ItemCount { get; set; }
-            public string FromMemberID { get; set; }
-            public string ToMemberID { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }	
-        }
-
-        public List<Model> Post(InputParams p)
+        public HttpResponseMessage Post(SelGiftItemToMeInputParams p)
         {
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<SelGiftItemToMeModel> result = new List<SelGiftItemToMeModel>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -85,7 +66,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                SelGiftItemToMeModel workItem = new SelGiftItemToMeModel()
                                 {
                                     GiftDepositoryID = dreader[0].ToString(),
                                     ItemListID = dreader[1].ToString(),
@@ -109,7 +90,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 

--- a/Controllers/CBSelItemListAllController.cs
+++ b/Controllers/CBSelItemListAllController.cs
@@ -32,53 +32,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBSelItemListAllController : ApiController
     {
-        
-        public class InputParams {
-            public string MemberID;     // log purpose
-            public Int64 Page; 
-            public Int64 PageSize;}
-
-        public class Model
+        public HttpResponseMessage Post(SelItemListAllInputParams p)
         {
-            public string ROWNUM { get; set; }
-            public string ItemListID { get; set; }
-            public string ItemName { get; set; }
-            public string ItemDescription { get; set; }
-            public string ItemPrice { get; set; }
-            public string ItemSellPrice { get; set; }
-            public string ItemCategory1 { get; set; }
-            public string ItemCategory2 { get; set; }
-            public string ItemCategory3 { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<SelItemListAllInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
-        }
-
-        public List<Model> Post(InputParams p)
-        {
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<SelItemListAllModel> result = new List<SelItemListAllModel>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -97,7 +84,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                SelItemListAllModel workItem = new SelItemListAllModel()
                                 {
                                     ROWNUM = dreader[0].ToString(),
                                     ItemListID = dreader[1].ToString(),
@@ -125,7 +112,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 
@@ -142,6 +147,5 @@ namespace CloudBread.Controllers
                 throw ex;
             }
         }
-
     }
 }

--- a/Controllers/CBSelNoticesController.cs
+++ b/Controllers/CBSelNoticesController.cs
@@ -31,56 +31,42 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBSelNoticesController : ApiController
     {
-        
-        public class InputParams { 
-            public string MemberID;     // log tasking purpose 
-        }
-
-        public class Model
+        //public List<Model> Post(InputParams p)   
+        public HttpResponseMessage Post(SelNoticesInputParams p)    
         {
-            public string NoticeID { get; set; }
-            public string NoticeCategory1 { get; set; }
-            public string NoticeCategory2 { get; set; }
-            public string NoticeCategory3 { get; set; }
-            public string TargetGroup { get; set; }
-            public string TargetOS { get; set; }
-            public string TargetDevice { get; set; }
-            public string NoticeImageLink { get; set; }
-            public string title { get; set; }
-            public string content { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<SelNoticesInputParams>(decrypted);
 
-        }
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
-        public List<Model> Post(InputParams p)   
-        {
-            //string sid = "";
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            //claimsPrincipal.GetType
-            //string sid = claimsPrincipal == null ? p.MemberID : CBAuth.getSID(claimsPrincipal);
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
 
-            List<Model> result = new List<Model>();
+            List<SelNoticesModel> result = new List<SelNoticesModel>();
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
 
             try
             {
@@ -97,7 +83,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                Model workItem = new Model()
+                                SelNoticesModel workItem = new SelNoticesModel()
                                 {
                                     NoticeID = dreader[0].ToString(),
                                     NoticeCategory1 = dreader[1].ToString(),
@@ -126,7 +112,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
                     }
-                    return result;
+
+                    /// Encrypt the result response
+                    if (globalVal.CloudBreadCryptSetting == "AES256")
+                    {
+                        try
+                        {
+                            encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(result), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                            response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                            return response;
+                        }
+                        catch (Exception ex)
+                        {
+                            ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                            throw ex;
+                        }
+                    }
+
+                    response = Request.CreateResponse(HttpStatusCode.OK, result);
+                    return response;
                 }
             }
 

--- a/Controllers/CBSelSendEmailToMemberController.cs
+++ b/Controllers/CBSelSendEmailToMemberController.cs
@@ -34,28 +34,41 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBSelSendEmailToMemberController : ApiController
     {
-
-        string result ="";
-        public class InputParams { 
-            public string memberID;
-        }
-
-        public string Post(InputParams p)
+        public HttpResponseMessage Post(SelSendEmailToMemberInputParams p)
         {
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<SelSendEmailToMemberInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
+
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.memberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.memberID, this.User as ClaimsPrincipal);
             p.memberID = sid;
 
             // check proper authentication of member who trigger this API (Admin or member with authorized)
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
+            RowcountResult rowcountResult = new RowcountResult();
 
             try
             {
@@ -72,7 +85,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowcountResult.result = dreader[0].ToString();
                             }
                             //////////////////////////////////////////////////////////////////////////////////////
                             //// mail sending module - reference CloudBreadlib/BAL/SendSMTPMail
@@ -85,9 +98,25 @@ namespace CloudBread.Controllers
                         }
                         connection.Close();
 
-                        return result;  // or return mail send result string s
-                    }
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowcountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
 
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
+                        return response;  // or return mail send result string s
+                    }
                 }
             }
 
@@ -104,6 +133,5 @@ namespace CloudBread.Controllers
                 throw ;
             }
         }
-
     }
 }

--- a/Controllers/CBSocketAuthController.cs
+++ b/Controllers/CBSocketAuthController.cs
@@ -50,8 +50,7 @@ namespace CloudBread.Controllers
             Payload payload = new Payload();
 
             /// Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID("debug", claimsPrincipal);  // only for log
+            string sid = CBAuth.getMemberID("debug", this.User as ClaimsPrincipal);  // only for log
             payload.sid = sid;
 
             /// logging purpose

--- a/Controllers/CBUdtConfirmedEmailAddressController.cs
+++ b/Controllers/CBUdtConfirmedEmailAddressController.cs
@@ -2,6 +2,9 @@
 * @file CBUdtConfirmedEmailAddressController.cs
 * @brief !not implemented \n
 * Confirm email address of member. \n
+
+* Do not need this API in CloudBread v2. This API is deplicated in v2.
+
 * Need todo : this controller made for email address validate and confirmation. \n
 * This controller could be accessed with mobile browser(without appkey authentication). \n
 * It has to be seperated in mobile app appkey authentication and provide hashed string for member email address param. \n 
@@ -12,94 +15,94 @@
 * @todo implement code logic
 */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Web.Http;
-using Microsoft.Azure.Mobile.Server; 
-using Microsoft.Azure.Mobile.Server.Config;
+//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Net;
+//using System.Net.Http;
+//using System.Web.Http;
+//using Microsoft.Azure.Mobile.Server; 
+//using Microsoft.Azure.Mobile.Server.Config;
 
-using System.Threading.Tasks;
-using System.Diagnostics;
-using Logger.Logging;
-using CloudBread.globals;
-using CloudBreadLib.BAL.Crypto;
-using System.Data;
-using System.Data.Sql;
-using System.Data.SqlClient;
-using Newtonsoft.Json;
-using CloudBreadAuth;
-using System.Security.Claims;
-using Microsoft.Practices.TransientFaultHandling;
-using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+//using System.Threading.Tasks;
+//using System.Diagnostics;
+//using Logger.Logging;
+//using CloudBread.globals;
+//using CloudBreadLib.BAL.Crypto;
+//using System.Data;
+//using System.Data.Sql;
+//using System.Data.SqlClient;
+//using Newtonsoft.Json;
+//using CloudBreadAuth;
+//using System.Security.Claims;
+//using Microsoft.Practices.TransientFaultHandling;
+//using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
 
-namespace CloudBread.Controllers
-{
-    // detour mobile app appkey authentication
-    [MobileAppController]
-    public class CBUdtConfirmedEmailAddressController : ApiController
-    {
-        string result;
+//namespace CloudBread.Controllers
+//{
+//    // detour mobile app appkey authentication
+//    [MobileAppController]
+//    public class CBUdtConfirmedEmailAddressController : ApiController
+//    {
+//        string result;
 
-        public class InputParams { 
-            public string memberID;         // todo list
-            public string memberPWD;
-        }
+//        public class InputParams { 
+//            public string memberID;         // todo list
+//            public string memberPWD;        // not working in CloudBread v2.
+//        }
 
-        public string Post(InputParams p)
-        {
-            // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.memberID, claimsPrincipal);
-            p.memberID = sid;
+//        public string Post(InputParams p)
+//        {
+//            // Get the sid or memberID of the current user.
+//            var claimsPrincipal = this.User as ClaimsPrincipal;
+//            string sid = CBAuth.getMemberID(p.memberID, claimsPrincipal);
+//            p.memberID = sid;
 
-            Logging.CBLoggers logMessage = new Logging.CBLoggers();
-            string jsonParam = JsonConvert.SerializeObject(p);
+//            Logging.CBLoggers logMessage = new Logging.CBLoggers();
+//            string jsonParam = JsonConvert.SerializeObject(p);
 
-            try
-            {
-                /// Database connection retry policy
-                RetryPolicy retryPolicy = new RetryPolicy<SqlAzureTransientErrorDetectionStrategy>(globalVal.conRetryCount, TimeSpan.FromSeconds(globalVal.conRetryFromSeconds));
-                using (SqlConnection connection = new SqlConnection(globalVal.DBConnectionString))
-                {
-                    using (SqlCommand command = new SqlCommand("uspUdtConfirmedEmailAddress", connection))
-                    {
-                        command.CommandType = CommandType.StoredProcedure;
-                        command.Parameters.Add("@MemberID", SqlDbType.NVarChar, -1).Value = p.memberID;
-                        command.Parameters.Add("@MemberPWD", SqlDbType.NVarChar, -1).Value = p.memberPWD;       /// do not use v2.0.0
-                        connection.OpenWithRetry(retryPolicy);
-                        using (SqlDataReader dreader = command.ExecuteReaderWithRetry(retryPolicy))
-                        {
-                            while (dreader.Read())
-                            {
-                                result =  dreader[0].ToString();
-                            }
+//            try
+//            {
+//                /// Database connection retry policy
+//                RetryPolicy retryPolicy = new RetryPolicy<SqlAzureTransientErrorDetectionStrategy>(globalVal.conRetryCount, TimeSpan.FromSeconds(globalVal.conRetryFromSeconds));
+//                using (SqlConnection connection = new SqlConnection(globalVal.DBConnectionString))
+//                {
+//                    using (SqlCommand command = new SqlCommand("uspUdtConfirmedEmailAddress", connection))
+//                    {
+//                        command.CommandType = CommandType.StoredProcedure;
+//                        command.Parameters.Add("@MemberID", SqlDbType.NVarChar, -1).Value = p.memberID;
+//                        command.Parameters.Add("@MemberPWD", SqlDbType.NVarChar, -1).Value = p.memberPWD;       /// do not use v2.0.0
+//                        connection.OpenWithRetry(retryPolicy);
+//                        using (SqlDataReader dreader = command.ExecuteReaderWithRetry(retryPolicy))
+//                        {
+//                            while (dreader.Read())
+//                            {
+//                                result =  dreader[0].ToString();
+//                            }
 
-                            dreader.Close();
-                        }
-                        connection.Close();
+//                            dreader.Close();
+//                        }
+//                        connection.Close();
 
-                        return result;
-                    }
+//                        return result;
+//                    }
 
-                }
-            }
+//                }
+//            }
 
-            catch (Exception ex)
-            {
-                // error log
-                logMessage.memberID = p.memberID;
-                logMessage.Level = "ERROR";
-                logMessage.Logger = "CBUdtConfirmedEmailAddressController";
-                logMessage.Message = jsonParam;
-                logMessage.Exception = ex.ToString();
-                Logging.RunLog(logMessage);
+//            catch (Exception ex)
+//            {
+//                // error log
+//                logMessage.memberID = p.memberID;
+//                logMessage.Level = "ERROR";
+//                logMessage.Logger = "CBUdtConfirmedEmailAddressController";
+//                logMessage.Message = jsonParam;
+//                logMessage.Exception = ex.ToString();
+//                Logging.RunLog(logMessage);
 
-                throw;
-            }
-        }
+//                throw;
+//            }
+//        }
 
-    }
-}
+//    }
+//}

--- a/Controllers/CBUdtCouponMemberController.cs
+++ b/Controllers/CBUdtCouponMemberController.cs
@@ -36,59 +36,41 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBUdtCouponMemberController : ApiController
     {
-        
-        public class InputParams
+        public HttpResponseMessage Post(UdtCouponMemberInputParams p)
         {
-            public string InsertORUpdate { get; set; }
-            public string CouponID_Coupon { get; set; }
-            public string MemberItemID_MemberItems { get; set; }
-            public string MemberID_MemberItems { get; set; }
-            public string ItemListID_MemberItems { get; set; }
-            public string ItemCount_MemberItems { get; set; }
-            public string ItemStatus_MemberItems { get; set; }
-            public string sCol1_MemberItems { get; set; }
-            public string sCol2_MemberItems { get; set; }
-            public string sCol3_MemberItems { get; set; }
-            public string sCol4_MemberItems { get; set; }
-            public string sCol5_MemberItems { get; set; }
-            public string sCol6_MemberItems { get; set; }
-            public string sCol7_MemberItems { get; set; }
-            public string sCol8_MemberItems { get; set; }
-            public string sCol9_MemberItems { get; set; }
-            public string sCol10_MemberItems { get; set; }
-            public string CouponID_CouponMember { get; set; }
-            public string MemberID_CouponMember { get; set; }
-            public string sCol1_CouponMember { get; set; }
-            public string sCol2_CouponMember { get; set; }
-            public string sCol3_CouponMember { get; set; }
-            public string sCol4_CouponMember { get; set; }
-            public string sCol5_CouponMember { get; set; }
-            public string sCol6_CouponMember { get; set; }
-            public string sCol7_CouponMember { get; set; }
-            public string sCol8_CouponMember { get; set; }
-            public string sCol9_CouponMember { get; set; }
-            public string sCol10_CouponMember { get; set; }
-
-        }
-
-        public string Post(InputParams p)
-        {
-            string result = "";
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<UdtCouponMemberInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID_CouponMember, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID_CouponMember, this.User as ClaimsPrincipal);
             p.MemberID_CouponMember = sid;
             p.MemberID_MemberItems = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
+            RowcountResult rowcountResult = new RowcountResult();
 
             try
             {
@@ -105,7 +87,6 @@ namespace CloudBread.Controllers
                 {
                     using (SqlCommand command = new SqlCommand("uspUdtCouponMember", connection))
                     {
-
                         command.CommandType = CommandType.StoredProcedure;
                         command.Parameters.Add("@InsertORUpdate", SqlDbType.NVarChar, -1).Value = p.InsertORUpdate.ToUpper();       // or GAMEINFO
                         command.Parameters.Add("@CouponID_Coupon", SqlDbType.NVarChar, -1).Value = p.CouponID_Coupon;
@@ -142,7 +123,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowcountResult.result = dreader[0].ToString();
                             }
                             dreader.Close();
                         }
@@ -155,9 +136,25 @@ namespace CloudBread.Controllers
                         logMessage.Message = jsonParam;
                         Logging.RunLog(logMessage);
 
-                        return result;
-                    }
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowcountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
 
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
+                        return response;
+                    }
                 }
             }
 
@@ -174,6 +171,5 @@ namespace CloudBread.Controllers
                 throw;
             }
         }
-
     }
 }

--- a/Controllers/CBUdtMoveGiftController.cs
+++ b/Controllers/CBUdtMoveGiftController.cs
@@ -32,45 +32,40 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBUdtMoveGiftController : ApiController
     {
-        
-        public class InputParams
+        public HttpResponseMessage Post(UdtMoveGiftInputParams p)
         {
-            public string InsertORUpdate { get; set; }
-            public string GiftDepositoryID { get; set; }
-            public string MemberItemID { get; set; }
-            public string MemberID { get; set; }
-            public string ItemListID { get; set; }
-            public string ItemCount { get; set; }
-            public string ItemStatus { get; set; }
-            public string sCol1 { get; set; }
-            public string sCol2 { get; set; }
-            public string sCol3 { get; set; }
-            public string sCol4 { get; set; }
-            public string sCol5 { get; set; }
-            public string sCol6 { get; set; }
-            public string sCol7 { get; set; }
-            public string sCol8 { get; set; }
-            public string sCol9 { get; set; }
-            public string sCol10 { get; set; }	
-        }
-
-        public string Post(InputParams p)
-        {
-            string result = "";
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<UdtMoveGiftInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID, this.User as ClaimsPrincipal);
             p.MemberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
+            RowcountResult rowcountResult = new RowcountResult();
 
             try
             {
@@ -111,7 +106,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowcountResult.result = dreader[0].ToString();
                             }
                             dreader.Close();
                         }
@@ -124,9 +119,25 @@ namespace CloudBread.Controllers
                         logMessage.Message = jsonParam;
                         Logging.RunLog(logMessage);
 
-                        return result;
-                    }
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowcountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
 
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
+                        return response;
+                    }
                 }
             }
 
@@ -143,6 +154,5 @@ namespace CloudBread.Controllers
                 throw;
             }
         }
-
     }
 }

--- a/Controllers/CBUdtReturnItemController.cs
+++ b/Controllers/CBUdtReturnItemController.cs
@@ -34,102 +34,42 @@ using CloudBreadAuth;
 using System.Security.Claims;
 using Microsoft.Practices.TransientFaultHandling;
 using Microsoft.Practices.EnterpriseLibrary.WindowsAzure.TransientFaultHandling.SqlAzure;
+using CloudBread.Models;
 
 namespace CloudBread.Controllers
 {
     [MobileAppController]
     public class CBUdtReturnItemController : ApiController
     {
-        
-        public class InputParams
+        public HttpResponseMessage Post(UdtReturnItemInputParams p)
         {
-            public string DeleteORUpdate { get; set; }
-            public string MemberItemID_MemberItems { get; set; }
-            public string MemberID_MemberItems { get; set; }
-            public string ItemListID_MemberItems { get; set; }
-            public string ItemCount_MemberItems { get; set; }
-            public string ItemStatus_MemberItems { get; set; }
-            public string sCol1_MemberItems { get; set; }
-            public string sCol2_MemberItems { get; set; }
-            public string sCol3_MemberItems { get; set; }
-            public string sCol4_MemberItems { get; set; }
-            public string sCol5_MemberItems { get; set; }
-            public string sCol6_MemberItems { get; set; }
-            public string sCol7_MemberItems { get; set; }
-            public string sCol8_MemberItems { get; set; }
-            public string sCol9_MemberItems { get; set; }
-            public string sCol10_MemberItems { get; set; }
-            public string MemberItemPurchaseID_MemberItemPurchases { get; set; }
-            public string MemberID_MemberItemPurchases { get; set; }
-            public string ItemListID_MemberItemPurchases { get; set; }
-            public string PurchaseQuantity_MemberItemPurchases { get; set; }
-            public string PurchasePrice_MemberItemPurchases { get; set; }
-            public string PGinfo1_MemberItemPurchases { get; set; }
-            public string PGinfo2_MemberItemPurchases { get; set; }
-            public string PGinfo3_MemberItemPurchases { get; set; }
-            public string PGinfo4_MemberItemPurchases { get; set; }
-            public string PGinfo5_MemberItemPurchases { get; set; }
-            public string PurchaseDeviceID_MemberItemPurchases { get; set; }
-            public string PurchaseDeviceIPAddress_MemberItemPurchases { get; set; }
-            public string PurchaseDeviceMACAddress_MemberItemPurchases { get; set; }
-            public string PurchaseDT_MemberItemPurchases { get; set; }
-            public string PurchaseCancelYN_MemberItemPurchases { get; set; }
-            public string PurchaseCancelDT_MemberItemPurchases { get; set; }
-            public string PurchaseCancelingStatus_MemberItemPurchases { get; set; }
-            public string PurchaseCancelReturnedAmount_MemberItemPurchases { get; set; }
-            public string PurchaseCancelDeviceID_MemberItemPurchases { get; set; }
-            public string PurchaseCancelDeviceIPAddress_MemberItemPurchases { get; set; }
-            public string PurchaseCancelDeviceMACAddress_MemberItemPurchases { get; set; }
-            public string sCol1_MemberItemPurchases { get; set; }
-            public string sCol2_MemberItemPurchases { get; set; }
-            public string sCol3_MemberItemPurchases { get; set; }
-            public string sCol4_MemberItemPurchases { get; set; }
-            public string sCol5_MemberItemPurchases { get; set; }
-            public string sCol6_MemberItemPurchases { get; set; }
-            public string sCol7_MemberItemPurchases { get; set; }
-            public string sCol8_MemberItemPurchases { get; set; }
-            public string sCol9_MemberItemPurchases { get; set; }
-            public string sCol10_MemberItemPurchases { get; set; }
-            public string MemberID_MemberGameInfoes { get; set; }
-            public string Level_MemberGameInfoes { get; set; }
-            public string Exps_MemberGameInfoes { get; set; }
-            public string Points_MemberGameInfoes { get; set; }
-            public string UserSTAT1_MemberGameInfoes { get; set; }
-            public string UserSTAT2_MemberGameInfoes { get; set; }
-            public string UserSTAT3_MemberGameInfoes { get; set; }
-            public string UserSTAT4_MemberGameInfoes { get; set; }
-            public string UserSTAT5_MemberGameInfoes { get; set; }
-            public string UserSTAT6_MemberGameInfoes { get; set; }
-            public string UserSTAT7_MemberGameInfoes { get; set; }
-            public string UserSTAT8_MemberGameInfoes { get; set; }
-            public string UserSTAT9_MemberGameInfoes { get; set; }
-            public string UserSTAT10_MemberGameInfoes { get; set; }
-            public string sCol1_MemberGameInfoes { get; set; }
-            public string sCol2_MemberGameInfoes { get; set; }
-            public string sCol3_MemberGameInfoes { get; set; }
-            public string sCol4_MemberGameInfoes { get; set; }
-            public string sCol5_MemberGameInfoes { get; set; }
-            public string sCol6_MemberGameInfoes { get; set; }
-            public string sCol7_MemberGameInfoes { get; set; }
-            public string sCol8_MemberGameInfoes { get; set; }
-            public string sCol9_MemberGameInfoes { get; set; }
-            public string sCol10_MemberGameInfoes { get; set; }
-
-        }
-
-        public string Post(InputParams p)
-        {
-            string result = "";
+            // try decrypt data
+            if (!string.IsNullOrEmpty(p.token) && globalVal.CloudBreadCryptSetting == "AES256")
+            {
+                try
+                {
+                    string decrypted = Crypto.AES_decrypt(p.token, globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                    p = JsonConvert.DeserializeObject<UdtReturnItemInputParams>(decrypted);
+                }
+                catch (Exception ex)
+                {
+                    ex = (Exception)Activator.CreateInstance(ex.GetType(), "Decrypt Error", ex);
+                    throw ex;
+                }
+            }
 
             // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.MemberID_MemberGameInfoes, claimsPrincipal);
+            string sid = CBAuth.getMemberID(p.MemberID_MemberGameInfoes, this.User as ClaimsPrincipal);
             p.MemberID_MemberGameInfoes = sid;
             p.MemberID_MemberItemPurchases = sid;
             p.MemberID_MemberItems = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);
+
+            HttpResponseMessage response = new HttpResponseMessage();
+            EncryptedData encryptedResult = new EncryptedData();
+            RowcountResult rowcountResult = new RowcountResult();
 
             try
             {
@@ -163,7 +103,6 @@ namespace CloudBread.Controllers
                         command.Parameters.Add("@sCol8_MemberItems", SqlDbType.NVarChar, -1).Value = p.sCol8_MemberItems;
                         command.Parameters.Add("@sCol9_MemberItems", SqlDbType.NVarChar, -1).Value = p.sCol9_MemberItems;
                         command.Parameters.Add("@sCol10_MemberItems", SqlDbType.NVarChar, -1).Value = p.sCol10_MemberItems;
-
                         command.Parameters.Add("@MemberItemPurchaseID_MemberItemPurchases", SqlDbType.NVarChar, -1).Value = p.MemberItemPurchaseID_MemberItemPurchases;
                         command.Parameters.Add("@MemberID_MemberItemPurchases", SqlDbType.NVarChar, -1).Value = p.MemberID_MemberItemPurchases;
                         command.Parameters.Add("@ItemListID_MemberItemPurchases", SqlDbType.NVarChar, -1).Value = p.ItemListID_MemberItemPurchases;
@@ -225,7 +164,7 @@ namespace CloudBread.Controllers
                         {
                             while (dreader.Read())
                             {
-                                result = dreader[0].ToString();
+                                rowcountResult.result = dreader[0].ToString();
                             }
                             dreader.Close();
                         }
@@ -238,9 +177,25 @@ namespace CloudBread.Controllers
                         logMessage.Message = jsonParam;
                         Logging.RunLog(logMessage);
 
-                        return result;
-                    }
+                        /// Encrypt the result response
+                        if (globalVal.CloudBreadCryptSetting == "AES256")
+                        {
+                            try
+                            {
+                                encryptedResult.token = Crypto.AES_encrypt(JsonConvert.SerializeObject(rowcountResult), globalVal.CloudBreadCryptKey, globalVal.CloudBreadCryptIV);
+                                response = Request.CreateResponse(HttpStatusCode.OK, encryptedResult);
+                                return response;
+                            }
+                            catch (Exception ex)
+                            {
+                                ex = (Exception)Activator.CreateInstance(ex.GetType(), "Encrypt Error", ex);
+                                throw ex;
+                            }
+                        }
 
+                        response = Request.CreateResponse(HttpStatusCode.OK, rowcountResult);
+                        return response;
+                    }
                 }
             }
 
@@ -257,6 +212,5 @@ namespace CloudBread.Controllers
                 throw;
             }
         }
-
     }
 }

--- a/DataObjects/globalVal.cs
+++ b/DataObjects/globalVal.cs
@@ -11,8 +11,11 @@ namespace CloudBread.globals
     {
         public static string DBConnectionString = ConfigurationManager.ConnectionStrings["CloudBreadDBConString"].ConnectionString;
         public static string StorageConnectionString = ConfigurationManager.ConnectionStrings["CloudBreadStorageConString"].ConnectionString;
-        public static string CloudBreadLoggerSetting = ConfigurationManager.AppSettings["CloudBreadLoggerSetting"].ToString();
-        public static string CloudBreadCryptSetting = ConfigurationManager.AppSettings["CloudBreadCryptSetting"].ToString();
+        public static string CloudBreadLoggerSetting = ConfigurationManager.AppSettings["CloudBreadLoggerSetting"];
+        public static string CloudBreadCryptSetting = ConfigurationManager.AppSettings["CloudBreadCryptSetting"];
+        public static string CloudBreadCryptKey = ConfigurationManager.AppSettings["CloudBreadCryptKey"];       /// adding v2.0.0
+        public static string CloudBreadCryptIV = ConfigurationManager.AppSettings["CloudBreadCryptIV"];       /// adding v2.0.0
+
         public static int conRetryCount = int.Parse(ConfigurationManager.AppSettings["CloudBreadconRetryCount"]);    /// adding v2.0.0
         public static int conRetryFromSeconds = int.Parse(ConfigurationManager.AppSettings["CloudBreadconRetryFromSeconds"]);     /// adding v2.0.0
         public static string CloudBreadSocketKeyText = ConfigurationManager.AppSettings["CloudBreadSocketKeyText"];     /// adding v2.0.0

--- a/Global.asax.cs
+++ b/Global.asax.cs
@@ -39,6 +39,8 @@ namespace CloudBread
                     tableClient.DefaultRequestOptions.RetryPolicy = retryPolicy;
                     var cloudTable = tableClient.GetTableReference("CloudBreadLog");
                     cloudTable.CreateIfNotExists();
+                    cloudTable = tableClient.GetTableReference("CloudBreadErrorLog");
+                    cloudTable.CreateIfNotExists();
 
                     /// this queue is used for CloudBread queue method game log saving
                     CloudQueueClient queueClient = storageAccount.CreateCloudQueueClient();

--- a/Models/AddMemberItemPurchase.cs
+++ b/Models/AddMemberItemPurchase.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class AddMemberItemPurchaseInputParams
+    {
+        public string InsertORUpdate { get; set; }
+        public string MemberItemID_MemberItems { get; set; }
+        public string MemberID_MemberItems { get; set; }
+        public string ItemListID_MemberItems { get; set; }
+        public string ItemCount_MemberItems { get; set; }
+        public string ItemStatus_MemberItems { get; set; }
+        public string sCol1_MemberItems { get; set; }
+        public string sCol2_MemberItems { get; set; }
+        public string sCol3_MemberItems { get; set; }
+        public string sCol4_MemberItems { get; set; }
+        public string sCol5_MemberItems { get; set; }
+        public string sCol6_MemberItems { get; set; }
+        public string sCol7_MemberItems { get; set; }
+        public string sCol8_MemberItems { get; set; }
+        public string sCol9_MemberItems { get; set; }
+        public string sCol10_MemberItems { get; set; }
+        public string MemberID_MemberItemPurchases { get; set; }
+        public string ItemListID_MemberItemPurchases { get; set; }
+        public string PurchaseQuantity_MemberItemPurchases { get; set; }
+        public string PurchasePrice_MemberItemPurchases { get; set; }
+        public string PGinfo1_MemberItemPurchases { get; set; }
+        public string PGinfo2_MemberItemPurchases { get; set; }
+        public string PGinfo3_MemberItemPurchases { get; set; }
+        public string PGinfo4_MemberItemPurchases { get; set; }
+        public string PGinfo5_MemberItemPurchases { get; set; }
+        public string PurchaseDeviceID_MemberItemPurchases { get; set; }
+        public string PurchaseDeviceIPAddress_MemberItemPurchases { get; set; }
+        public string PurchaseDeviceMACAddress_MemberItemPurchases { get; set; }
+        public string PurchaseDT_MemberItemPurchases { get; set; }
+        public string PurchaseCancelYN_MemberItemPurchases { get; set; }
+        public string PurchaseCancelDT_MemberItemPurchases { get; set; }
+        public string PurchaseCancelingStatus_MemberItemPurchases { get; set; }
+        public string PurchaseCancelReturnedAmount_MemberItemPurchases { get; set; }
+        public string PurchaseCancelDeviceID_MemberItemPurchases { get; set; }
+        public string PurchaseCancelDeviceIPAddress_MemberItemPurchases { get; set; }
+        public string PurchaseCancelDeviceMACAddress_MemberItemPurchases { get; set; }
+        public string sCol1_MemberItemPurchases { get; set; }
+        public string sCol2_MemberItemPurchases { get; set; }
+        public string sCol3_MemberItemPurchases { get; set; }
+        public string sCol4_MemberItemPurchases { get; set; }
+        public string sCol5_MemberItemPurchases { get; set; }
+        public string sCol6_MemberItemPurchases { get; set; }
+        public string sCol7_MemberItemPurchases { get; set; }
+        public string sCol8_MemberItemPurchases { get; set; }
+        public string sCol9_MemberItemPurchases { get; set; }
+        public string sCol10_MemberItemPurchases { get; set; }
+        public string MemberID_MemberGameInfoes { get; set; }
+        public string Level_MemberGameInfoes { get; set; }
+        public string Exps_MemberGameInfoes { get; set; }
+        public string Points_MemberGameInfoes { get; set; }
+        public string UserSTAT1_MemberGameInfoes { get; set; }
+        public string UserSTAT2_MemberGameInfoes { get; set; }
+        public string UserSTAT3_MemberGameInfoes { get; set; }
+        public string UserSTAT4_MemberGameInfoes { get; set; }
+        public string UserSTAT5_MemberGameInfoes { get; set; }
+        public string UserSTAT6_MemberGameInfoes { get; set; }
+        public string UserSTAT7_MemberGameInfoes { get; set; }
+        public string UserSTAT8_MemberGameInfoes { get; set; }
+        public string UserSTAT9_MemberGameInfoes { get; set; }
+        public string UserSTAT10_MemberGameInfoes { get; set; }
+        public string sCol1_MemberGameInfoes { get; set; }
+        public string sCol2_MemberGameInfoes { get; set; }
+        public string sCol3_MemberGameInfoes { get; set; }
+        public string sCol4_MemberGameInfoes { get; set; }
+        public string sCol5_MemberGameInfoes { get; set; }
+        public string sCol6_MemberGameInfoes { get; set; }
+        public string sCol7_MemberGameInfoes { get; set; }
+        public string sCol8_MemberGameInfoes { get; set; }
+        public string sCol9_MemberGameInfoes { get; set; }
+        public string sCol10_MemberGameInfoes { get; set; }
+        public string token { get; set; }
+
+    }
+}

--- a/Models/AddUseMemberItem.cs
+++ b/Models/AddUseMemberItem.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class AddUseMemberItemInputParams
+    {
+        public string InsertORUpdateORDelete { get; set; }
+        public string MemberItemID_MemberItem { get; set; }
+        public string MemberID_MemberItem { get; set; }
+        public string ItemListID_MemberItem { get; set; }
+        public string ItemCount_MemberItem { get; set; }
+        public string ItemStatus_MemberItem { get; set; }
+        public string sCol1_MemberItem { get; set; }
+        public string sCol2_MemberItem { get; set; }
+        public string sCol3_MemberItem { get; set; }
+        public string sCol4_MemberItem { get; set; }
+        public string sCol5_MemberItem { get; set; }
+        public string sCol6_MemberItem { get; set; }
+        public string sCol7_MemberItem { get; set; }
+        public string sCol8_MemberItem { get; set; }
+        public string sCol9_MemberItem { get; set; }
+        public string sCol10_MemberItem { get; set; }
+        public string MemberID_MemberGameInfoes { get; set; }
+        public string Level_MemberGameInfoes { get; set; }
+        public string Exps_MemberGameInfoes { get; set; }
+        public string Points_MemberGameInfoes { get; set; }
+        public string UserSTAT1_MemberGameInfoes { get; set; }
+        public string UserSTAT2_MemberGameInfoes { get; set; }
+        public string UserSTAT3_MemberGameInfoes { get; set; }
+        public string UserSTAT4_MemberGameInfoes { get; set; }
+        public string UserSTAT5_MemberGameInfoes { get; set; }
+        public string UserSTAT6_MemberGameInfoes { get; set; }
+        public string UserSTAT7_MemberGameInfoes { get; set; }
+        public string UserSTAT8_MemberGameInfoes { get; set; }
+        public string UserSTAT9_MemberGameInfoes { get; set; }
+        public string UserSTAT10_MemberGameInfoes { get; set; }
+        public string sCol1_MemberGameInfoes { get; set; }
+        public string sCol2_MemberGameInfoes { get; set; }
+        public string sCol3_MemberGameInfoes { get; set; }
+        public string sCol4_MemberGameInfoes { get; set; }
+        public string sCol5_MemberGameInfoes { get; set; }
+        public string sCol6_MemberGameInfoes { get; set; }
+        public string sCol7_MemberGameInfoes { get; set; }
+        public string sCol8_MemberGameInfoes { get; set; }
+        public string sCol9_MemberGameInfoes { get; set; }
+        public string sCol10_MemberGameInfoes { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/COMUdtMember.cs
+++ b/Models/COMUdtMember.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class COMUdtMemberInputParams
+    {
+        public string MemberID { get; set; }
+        public string MemberPWD { get; set; }   // CloudBread 2.0.0-beta deplicated. Use 3rd party authentication by default.
+        public string EmailAddress { get; set; }
+        public string EmailConfirmedYN { get; set; }
+        public string PhoneNumber1 { get; set; }
+        public string PhoneNumber2 { get; set; }
+        public string PINumber { get; set; }
+        public string Name1 { get; set; }
+        public string Name2 { get; set; }
+        public string Name3 { get; set; }
+        public string DOB { get; set; }
+        public string RecommenderID { get; set; }
+        public string MemberGroup { get; set; }
+        public string LastDeviceID { get; set; }
+        public string LastIPaddress { get; set; }
+        public string LastLoginDT { get; set; }
+        public string LastLogoutDT { get; set; }
+        public string LastMACAddress { get; set; }
+        public string AccountBlockYN { get; set; }
+        public string AccountBlockEndDT { get; set; }
+        public string AnonymousYN { get; set; }
+        public string _3rdAuthProvider { get; set; }
+        public string _3rdAuthID { get; set; }
+        public string _3rdAuthParam { get; set; }
+        public string PushNotificationID { get; set; }
+        public string PushNotificationProvider { get; set; }
+        public string PushNotificationGroup { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+        public string TimeZoneID { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/ComInsMemberItemPurchase.cs
+++ b/Models/ComInsMemberItemPurchase.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComInsMemberItemPurchaseInputParams
+    {
+        public string MemberItemPurchaseID { get; set; }
+        public string MemberID { get; set; }
+        public string ItemListID { get; set; }
+        public string PurchaseQuantity { get; set; }
+        public string PurchasePrice { get; set; }
+        public string PGinfo1 { get; set; }
+        public string PGinfo2 { get; set; }
+        public string PGinfo3 { get; set; }
+        public string PGinfo4 { get; set; }
+        public string PGinfo5 { get; set; }
+        public string PurchaseDeviceID { get; set; }
+        public string PurchaseDeviceIPAddress { get; set; }
+        public string PurchaseDeviceMACAddress { get; set; }
+        public string PurchaseDT { get; set; }
+        public string PurchaseCancelYN { get; set; }
+        public string PurchaseCancelDT { get; set; }
+        public string PurchaseCancelingStatus { get; set; }
+        public string PurchaseCancelReturnedAmount { get; set; }
+        public string PurchaseCancelDeviceID { get; set; }
+        public string PurchaseCancelDeviceIPAddress { get; set; }
+        public string PurchaseCancelDeviceMACAddress { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/ComSelCoupon.cs
+++ b/Models/ComSelCoupon.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComSelCouponInputParams
+    {
+        public string MemberID { get; set; }     // log purpose
+        public string CouponID { get; set; }
+        public string token { get; set; }
+    }
+
+    public class ComSelCouponModel
+    {
+        public string CouponID { get; set; }
+        public string CouponCategory1 { get; set; }
+        public string CouponCategory2 { get; set; }
+        public string CouponCategory3 { get; set; }
+        public string ItemListID { get; set; }
+        public string ItemCount { get; set; }
+        public string ItemStatus { get; set; }
+        public string TargetGroup { get; set; }
+        public string TargetOS { get; set; }
+        public string TargetDevice { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/ComSelGiftDepository.cs
+++ b/Models/ComSelGiftDepository.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComSelGiftDepositoryInputParams
+    {
+        public string MemberID;     // log purpose
+        public string GiftDepositoryID;
+        public string token;
+    }
+
+    public class ComSelGiftDepositoryModel
+    {
+        public string GiftDepositoryID { get; set; }
+        public string ItemListID { get; set; }
+        public string ItemCount { get; set; }
+        public string FromMemberID { get; set; }
+        public string ToMemberID { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/ComSelItemList1.cs
+++ b/Models/ComSelItemList1.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComSelItemList1InputParams
+    {
+        public string MemberID;     // log purpose
+        public string ItemListID;
+        public string token;
+    }
+
+    public class ComSelItemList1Model
+    {
+        public string ItemListID { get; set; }
+        public string ItemName { get; set; }
+        public string ItemDescription { get; set; }
+        public string ItemPrice { get; set; }
+        public string ItemSellPrice { get; set; }
+        public string ItemCategory1 { get; set; }
+        public string ItemCategory2 { get; set; }
+        public string ItemCategory3 { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+
+}

--- a/Models/ComSelMember.cs
+++ b/Models/ComSelMember.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComSelMemberInputParams
+    {
+        public string memberID;
+        public string token;
+    }
+
+    public class ComSelMemberModel
+    {
+        public string MemberID { get; set; }
+        public string MemberPWD { get; set; }
+        public string EmailAddress { get; set; }
+        public string EmailConfirmedYN { get; set; }
+        public string PhoneNumber1 { get; set; }
+        public string PhoneNumber2 { get; set; }
+        public string PINumber { get; set; }
+        public string Name1 { get; set; }
+        public string Name2 { get; set; }
+        public string Name3 { get; set; }
+        public string DOB { get; set; }
+        public string RecommenderID { get; set; }
+        public string MemberGroup { get; set; }
+        public string LastDeviceID { get; set; }
+        public string LastIPaddress { get; set; }
+        public string LastLoginDT { get; set; }
+        public string LastLogoutDT { get; set; }
+        public string LastMACAddress { get; set; }
+        public string AccountBlockYN { get; set; }
+        public string AccountBlockEndDT { get; set; }
+        public string AnonymousYN { get; set; }
+        public string _3rdAuthProvider { get; set; }
+        public string _3rdAuthID { get; set; }
+        public string _3rdAuthParam { get; set; }
+        public string PushNotificationID { get; set; }
+        public string PushNotificationProvider { get; set; }
+        public string PushNotificationGroup { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/ComSelMemberGameInfoStages.cs
+++ b/Models/ComSelMemberGameInfoStages.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComSelMemberGameInfoStagesInputParams
+    {
+        public string MemberID { get; set; }    // log purpose
+        public string MemberGameInfoStageID { get; set; }
+        public string token { get; set; }
+    }
+
+    public class ComSelMemberGameInfoStagesModel
+    {
+        public string MemberGameInfoStageID { get; set; }
+        public string MemberID { get; set; }
+        public string StageName { get; set; }
+        public string StageStatus { get; set; }
+        public string Category1 { get; set; }
+        public string Category2 { get; set; }
+        public string Category3 { get; set; }
+        public string Mission1 { get; set; }
+        public string Mission2 { get; set; }
+        public string Mission3 { get; set; }
+        public string Mission4 { get; set; }
+        public string Mission5 { get; set; }
+        public string Points { get; set; }
+        public string StageStat1 { get; set; }
+        public string StageStat2 { get; set; }
+        public string StageStat3 { get; set; }
+        public string StageStat4 { get; set; }
+        public string StageStat5 { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/ComSelMemberGameInfoes.cs
+++ b/Models/ComSelMemberGameInfoes.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComSelMemberGameInfoesInputParams
+    {
+        public string MemberID { get; set; }
+        public string token { get; set; }
+    }
+
+    public class ComSelMemberGameInfoesModel
+    {
+        public string MemberID { get; set; }
+        public string Level { get; set; }
+        public string Exps { get; set; }
+        public string Points { get; set; }
+        public string UserSTAT1 { get; set; }
+        public string UserSTAT2 { get; set; }
+        public string UserSTAT3 { get; set; }
+        public string UserSTAT4 { get; set; }
+        public string UserSTAT5 { get; set; }
+        public string UserSTAT6 { get; set; }
+        public string UserSTAT7 { get; set; }
+        public string UserSTAT8 { get; set; }
+        public string UserSTAT9 { get; set; }
+        public string UserSTAT10 { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/ComSelMemberItem.cs
+++ b/Models/ComSelMemberItem.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComSelMemberItemInputParams
+    {
+        public string MemberID { get; set; }     // log purpose
+        public string MemberItemID { get; set; }
+        public string token { get; set; }
+    }
+
+    public class ComSelMemberItemModel
+    {
+        public string MemberItemID { get; set; }
+        public string MemberID { get; set; }
+        public string ItemListID { get; set; }
+        public string ItemCount { get; set; }
+        public string ItemStatus { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/ComSelMemberItemPurchase.cs
+++ b/Models/ComSelMemberItemPurchase.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComSelMemberItemPurchaseInputParams
+    {
+        public string MemberID { get; set; }     // log purpose
+        public string MemberItemPurchaseID { get; set; }
+        public string token { get; set; }
+    }
+
+    public class ComSelMemberItemPurchaseModel
+    {
+        public string MemberItemPurchaseID { get; set; }
+        public string MemberID { get; set; }
+        public string ItemListID { get; set; }
+        public string PurchaseQuantity { get; set; }
+        public string PurchasePrice { get; set; }
+        public string PGinfo1 { get; set; }
+        public string PGinfo2 { get; set; }
+        public string PGinfo3 { get; set; }
+        public string PGinfo4 { get; set; }
+        public string PGinfo5 { get; set; }
+        public string PurchaseDeviceID { get; set; }
+        public string PurchaseDeviceIPAddress { get; set; }
+        public string PurchaseDeviceMACAddress { get; set; }
+        public string PurchaseDT { get; set; }
+        public string PurchaseCancelYN { get; set; }
+        public string PurchaseCancelDT { get; set; }
+        public string PurchaseCancelingStatus { get; set; }
+        public string PurchaseCancelReturnedAmount { get; set; }
+        public string PurchaseCancelDeviceID { get; set; }
+        public string PurchaseCancelDeviceIPAddress { get; set; }
+        public string PurchaseCancelDeviceMACAddress { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/ComUdtGiftDepository.cs
+++ b/Models/ComUdtGiftDepository.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComUdtGiftDepositoryInputParams
+    {
+        public string MemberID;
+        public string GiftDepositoryID { get; set; }
+        public string ItemListID { get; set; }
+        public string ItemCount { get; set; }
+        public string FromMemberID { get; set; }
+        public string ToMemberID { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/ComUdtMemberGameInfoStages.cs
+++ b/Models/ComUdtMemberGameInfoStages.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComUdtMemberGameInfoStagesInputParams
+    {
+        public string MemberGameInfoStageID { get; set; }
+        public string MemberID { get; set; }
+        public string StageName { get; set; }
+        public string StageStatus { get; set; }
+        public string Category1 { get; set; }
+        public string Category2 { get; set; }
+        public string Category3 { get; set; }
+        public string Mission1 { get; set; }
+        public string Mission2 { get; set; }
+        public string Mission3 { get; set; }
+        public string Mission4 { get; set; }
+        public string Mission5 { get; set; }
+        public string Points { get; set; }
+        public string StageStat1 { get; set; }
+        public string StageStat2 { get; set; }
+        public string StageStat3 { get; set; }
+        public string StageStat4 { get; set; }
+        public string StageStat5 { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/ComUdtMemberGameInfoes.cs
+++ b/Models/ComUdtMemberGameInfoes.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComUdtMemberGameInfoesInputParams
+    {
+        public string MemberID { get; set; }
+        public string Level { get; set; }
+        public string Exps { get; set; }
+        public string Points { get; set; }
+        public string UserSTAT1 { get; set; }
+        public string UserSTAT2 { get; set; }
+        public string UserSTAT3 { get; set; }
+        public string UserSTAT4 { get; set; }
+        public string UserSTAT5 { get; set; }
+        public string UserSTAT6 { get; set; }
+        public string UserSTAT7 { get; set; }
+        public string UserSTAT8 { get; set; }
+        public string UserSTAT9 { get; set; }
+        public string UserSTAT10 { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/ComUdtMemberItem.cs
+++ b/Models/ComUdtMemberItem.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComUdtMemberItemInputParams
+    {
+        public string MemberItemID { get; set; }
+        public string MemberID { get; set; }
+        public string ItemListID { get; set; }
+        public string ItemCount { get; set; }
+        public string ItemStatus { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/ComUdtMemberItemPurchase.cs
+++ b/Models/ComUdtMemberItemPurchase.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class ComUdtMemberItemPurchaseInputParams
+    {
+        public string MemberItemPurchaseID { get; set; }
+        public string MemberID { get; set; }
+        public string ItemListID { get; set; }
+        public string PurchaseQuantity { get; set; }
+        public string PurchasePrice { get; set; }
+        public string PGinfo1 { get; set; }
+        public string PGinfo2 { get; set; }
+        public string PGinfo3 { get; set; }
+        public string PGinfo4 { get; set; }
+        public string PGinfo5 { get; set; }
+        public string PurchaseDeviceID { get; set; }
+        public string PurchaseDeviceIPAddress { get; set; }
+        public string PurchaseDeviceMACAddress { get; set; }
+        public string PurchaseDT { get; set; }
+        public string PurchaseCancelYN { get; set; }
+        public string PurchaseCancelDT { get; set; }
+        public string PurchaseCancelingStatus { get; set; }
+        public string PurchaseCancelReturnedAmount { get; set; }
+        public string PurchaseCancelDeviceID { get; set; }
+        public string PurchaseCancelDeviceIPAddress { get; set; }
+        public string PurchaseCancelDeviceMACAddress { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/EncryptedData.cs
+++ b/Models/EncryptedData.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class EncryptedData
+    {
+        public string token { get; set; }
+    }
+}

--- a/Models/InsRegMember.cs
+++ b/Models/InsRegMember.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class InsRegMemberInputParams
+    {
+        public string MemberID_Members { get; set; }
+        public string MemberPWD_Members { get; set; }
+        public string EmailAddress_Members { get; set; }
+        public string EmailConfirmedYN_Members { get; set; }
+        public string PhoneNumber1_Members { get; set; }
+        public string PhoneNumber2_Members { get; set; }
+        public string PINumber_Members { get; set; }
+        public string Name1_Members { get; set; }
+        public string Name2_Members { get; set; }
+        public string Name3_Members { get; set; }
+        public string DOB_Members { get; set; }
+        public string RecommenderID_Members { get; set; }
+        public string MemberGroup_Members { get; set; }
+        public string LastDeviceID_Members { get; set; }
+        public string LastIPaddress_Members { get; set; }
+        public string LastLoginDT_Members { get; set; }
+        public string LastLogoutDT_Members { get; set; }
+        public string LastMACAddress_Members { get; set; }
+        public string AccountBlockYN_Members { get; set; }
+        public string AccountBlockEndDT_Members { get; set; }
+        public string AnonymousYN_Members { get; set; }
+        public string _3rdAuthProvider_Members { get; set; }
+        public string _3rdAuthID_Members { get; set; }
+        public string _3rdAuthParam_Members { get; set; }
+        public string PushNotificationID_Members { get; set; }
+        public string PushNotificationProvider_Members { get; set; }
+        public string PushNotificationGroup_Members { get; set; }
+        public string sCol1_Members { get; set; }
+        public string sCol2_Members { get; set; }
+        public string sCol3_Members { get; set; }
+        public string sCol4_Members { get; set; }
+        public string sCol5_Members { get; set; }
+        public string sCol6_Members { get; set; }
+        public string sCol7_Members { get; set; }
+        public string sCol8_Members { get; set; }
+        public string sCol9_Members { get; set; }
+        public string sCol10_Members { get; set; }
+        public string TimeZoneID_Members { get; set; }
+        public string Level_MemberGameInfoes { get; set; }
+        public string Exps_MemberGameInfoes { get; set; }
+        public string Points_MemberGameInfoes { get; set; }
+        public string UserSTAT1_MemberGameInfoes { get; set; }
+        public string UserSTAT2_MemberGameInfoes { get; set; }
+        public string UserSTAT3_MemberGameInfoes { get; set; }
+        public string UserSTAT4_MemberGameInfoes { get; set; }
+        public string UserSTAT5_MemberGameInfoes { get; set; }
+        public string UserSTAT6_MemberGameInfoes { get; set; }
+        public string UserSTAT7_MemberGameInfoes { get; set; }
+        public string UserSTAT8_MemberGameInfoes { get; set; }
+        public string UserSTAT9_MemberGameInfoes { get; set; }
+        public string UserSTAT10_MemberGameInfoes { get; set; }
+        public string sCol1_MemberGameInfoes { get; set; }
+        public string sCol2_MemberGameInfoes { get; set; }
+        public string sCol3_MemberGameInfoes { get; set; }
+        public string sCol4_MemberGameInfoes { get; set; }
+        public string sCol5_MemberGameInfoes { get; set; }
+        public string sCol6_MemberGameInfoes { get; set; }
+        public string sCol7_MemberGameInfoes { get; set; }
+        public string sCol8_MemberGameInfoes { get; set; }
+        public string sCol9_MemberGameInfoes { get; set; }
+        public string sCol10_MemberGameInfoes { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/RowcountResult.cs
+++ b/Models/RowcountResult.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class RowcountResult
+    {
+        public string result { get; set; }
+    }
+}

--- a/Models/SelGameEvents.cs
+++ b/Models/SelGameEvents.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelGameEventsInputParams {
+        public string MemberID { get; set; }
+        public string token { get; set; }
+    }
+
+    public class SelGameEventsModel
+    {
+        public string GameEventID { get; set; }
+        public string eventCategory1 { get; set; }
+        public string eventCategory2 { get; set; }
+        public string eventCategory3 { get; set; }
+        public string ItemListID { get; set; }
+        public string ItemCount { get; set; }
+        public string Itemstatus { get; set; }
+        public string TargetGroup { get; set; }
+        public string TargetOS { get; set; }
+        public string TargetDevice { get; set; }
+        public string EventImageLink { get; set; }
+        public string Title { get; set; }
+        public string Content { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/SelGiftItemToMe.cs
+++ b/Models/SelGiftItemToMe.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelGiftItemToMeInputParams
+    {
+        public string MemberID { get; set; }
+        public string token { get; set; }
+    }
+
+    public class SelGiftItemToMeModel
+    {
+        public string GiftDepositoryID { get; set; }
+        public string ItemListID { get; set; }
+        public string ItemCount { get; set; }
+        public string FromMemberID { get; set; }
+        public string ToMemberID { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/SelItem1.cs
+++ b/Models/SelItem1.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelItem1InputParams
+    {
+        public string MemberID { get; set; }     // log purpose
+        public string ItemListID { get; set; }
+        public string token { get; set; }
+    }
+
+    public class SelItem1Model
+    {
+        public string ItemListID { get; set; }
+        public string ItemName { get; set; }
+        public string ItemDescription { get; set; }
+        public string ItemPrice { get; set; }
+        public string ItemSellPrice { get; set; }
+        public string ItemCategory1 { get; set; }
+        public string ItemCategory2 { get; set; }
+        public string ItemCategory3 { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/SelItemListAll.cs
+++ b/Models/SelItemListAll.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelItemListAllInputParams
+    {
+        public string MemberID { get; set; }     // log purpose
+        public Int64 Page { get; set; }
+        public Int64 PageSize { get; set; }
+        public string token { get; set; }
+    }
+
+    public class SelItemListAllModel
+    {
+        public string ROWNUM { get; set; }
+        public string ItemListID { get; set; }
+        public string ItemName { get; set; }
+        public string ItemDescription { get; set; }
+        public string ItemPrice { get; set; }
+        public string ItemSellPrice { get; set; }
+        public string ItemCategory1 { get; set; }
+        public string ItemCategory2 { get; set; }
+        public string ItemCategory3 { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/SelLoginIDDupeCheck.cs
+++ b/Models/SelLoginIDDupeCheck.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelLoginIDDupeCheckInputParams
+    {
+        public string memberID { get; set; }
+        public string token { get; set; }
+    }
+
+    //return json
+    public class SelLoginIDDupeCheckResult
+    {
+        public string result { get; set; }
+    }
+}

--- a/Models/SelLoginInfo.cs
+++ b/Models/SelLoginInfo.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelLoginInfoInputParams
+    {
+        public string memberID { get; set; }
+        public string memberPWD { get; set; }        // Consider using 3rd party authentication. If using own autehtication, at least SHA512 from client device.
+        public string LastDeviceID { get; set; }
+        public string LastIPaddress { get; set; }
+        public string LastMACAddress { get; set; }
+        public string token { get; set; }
+    }
+
+    public class SelLoginInfoModel
+    {
+        public string MemberID { get; set; }
+        public string MemberPWD { get; set; }
+        public string EmailAddress { get; set; }
+        public string EmailConfirmedYN { get; set; }
+        public string PhoneNumber1 { get; set; }
+        public string PhoneNumber2 { get; set; }
+        public string PINumber { get; set; }
+        public string Name1 { get; set; }
+        public string Name2 { get; set; }
+        public string Name3 { get; set; }
+        public string DOB { get; set; }
+        public string RecommenderID { get; set; }
+        public string MemberGroup { get; set; }
+        public string LastDeviceID { get; set; }
+        public string LastIPaddress { get; set; }
+        public string LastLoginDT { get; set; }
+        public string LastLogoutDT { get; set; }
+        public string LastMACAddress { get; set; }
+        public string AccountBlockYN { get; set; }
+        public string AccountBlockEndDT { get; set; }
+        public string AnonymousYN { get; set; }
+        public string _3rdAuthProvider { get; set; }
+        public string _3rdAuthID { get; set; }
+        public string _3rdAuthParam { get; set; }
+        public string PushNotificationID { get; set; }
+        public string PushNotificationProvider { get; set; }
+        public string PushNotificationGroup { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/SelMemberGameInfoStages.cs
+++ b/Models/SelMemberGameInfoStages.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelMemberGameInfoStagesInputParams
+    {
+        public string memberID { get; set; }
+        public string token { get; set; }
+    }
+
+    public class SelMemberGameInfoStagesModel
+    {
+        public string MemberGameInfoStageID { get; set; }
+        public string MemberID { get; set; }
+        public string StageName { get; set; }
+        public string StageStatus { get; set; }
+        public string Category1 { get; set; }
+        public string Category2 { get; set; }
+        public string Category3 { get; set; }
+        public string Mission1 { get; set; }
+        public string Mission2 { get; set; }
+        public string Mission3 { get; set; }
+        public string Mission4 { get; set; }
+        public string Mission5 { get; set; }
+        public string Points { get; set; }
+        public string StageStat1 { get; set; }
+        public string StageStat2 { get; set; }
+        public string StageStat3 { get; set; }
+        public string StageStat4 { get; set; }
+        public string StageStat5 { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/SelMemberItems.cs
+++ b/Models/SelMemberItems.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelMemberItemsInputParams
+    {
+        public string MemberID { get; set; }
+        public Int64 Page { get; set; }
+        public Int64 PageSize { get; set; }
+        public string token { get; set; }
+    }
+
+    public class SelMemberItemsModel
+    {
+        public string ROWNUM { get; set; }
+        public string ItemListsItemName { get; set; }
+        public string ItemListsItemDescription { get; set; }
+        public string ItemListsItemPrice { get; set; }
+        public string ItemListsItemSellPrice { get; set; }
+        public string ItemListsItemCategory1 { get; set; }
+        public string ItemListsItemCategory2 { get; set; }
+        public string ItemListsItemCategory3 { get; set; }
+        public string ItemListssCol1 { get; set; }
+        public string ItemListssCol2 { get; set; }
+        public string ItemListssCol3 { get; set; }
+        public string ItemListssCol4 { get; set; }
+        public string ItemListssCol5 { get; set; }
+        public string ItemListssCol6 { get; set; }
+        public string ItemListssCol7 { get; set; }
+        public string ItemListssCol8 { get; set; }
+        public string ItemListssCol9 { get; set; }
+        public string ItemListssCol10 { get; set; }
+        public string MemberItemsMemberItemID { get; set; }
+        public string MemberItemsMemberID { get; set; }
+        public string MemberItemsItemListID { get; set; }
+        public string MemberItemsItemCount { get; set; }
+        public string MemberItemsItemStatus { get; set; }
+        public string MemberItemssCol1 { get; set; }
+        public string MemberItemssCol2 { get; set; }
+        public string MemberItemssCol3 { get; set; }
+        public string MemberItemssCol4 { get; set; }
+        public string MemberItemssCol5 { get; set; }
+        public string MemberItemssCol6 { get; set; }
+        public string MemberItemssCol7 { get; set; }
+        public string MemberItemssCol8 { get; set; }
+        public string MemberItemssCol9 { get; set; }
+        public string MemberItemssCol10 { get; set; }
+    }
+}

--- a/Models/SelNotices.cs
+++ b/Models/SelNotices.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelNoticesInputParams
+    {
+        public string MemberID { get; set; }     // log tasking purpose 
+        public string token { get; set; }
+    }
+
+    public class SelNoticesModel
+    {
+        public string NoticeID { get; set; }
+        public string NoticeCategory1 { get; set; }
+        public string NoticeCategory2 { get; set; }
+        public string NoticeCategory3 { get; set; }
+        public string TargetGroup { get; set; }
+        public string TargetOS { get; set; }
+        public string TargetDevice { get; set; }
+        public string NoticeImageLink { get; set; }
+        public string title { get; set; }
+        public string content { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+    }
+}

--- a/Models/SelSendEmailToMember.cs
+++ b/Models/SelSendEmailToMember.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class SelSendEmailToMemberInputParams
+    {
+        public string memberID { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/UdtCouponMember.cs
+++ b/Models/UdtCouponMember.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class UdtCouponMemberInputParams
+    {
+        public string InsertORUpdate { get; set; }
+        public string CouponID_Coupon { get; set; }
+        public string MemberItemID_MemberItems { get; set; }
+        public string MemberID_MemberItems { get; set; }
+        public string ItemListID_MemberItems { get; set; }
+        public string ItemCount_MemberItems { get; set; }
+        public string ItemStatus_MemberItems { get; set; }
+        public string sCol1_MemberItems { get; set; }
+        public string sCol2_MemberItems { get; set; }
+        public string sCol3_MemberItems { get; set; }
+        public string sCol4_MemberItems { get; set; }
+        public string sCol5_MemberItems { get; set; }
+        public string sCol6_MemberItems { get; set; }
+        public string sCol7_MemberItems { get; set; }
+        public string sCol8_MemberItems { get; set; }
+        public string sCol9_MemberItems { get; set; }
+        public string sCol10_MemberItems { get; set; }
+        public string CouponID_CouponMember { get; set; }
+        public string MemberID_CouponMember { get; set; }
+        public string sCol1_CouponMember { get; set; }
+        public string sCol2_CouponMember { get; set; }
+        public string sCol3_CouponMember { get; set; }
+        public string sCol4_CouponMember { get; set; }
+        public string sCol5_CouponMember { get; set; }
+        public string sCol6_CouponMember { get; set; }
+        public string sCol7_CouponMember { get; set; }
+        public string sCol8_CouponMember { get; set; }
+        public string sCol9_CouponMember { get; set; }
+        public string sCol10_CouponMember { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/UdtGameEventMemberToItem.cs
+++ b/Models/UdtGameEventMemberToItem.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class UdtGameEventMemberToItemInputParams
+    {
+        public string InsertORUpdate { get; set; }
+        public string MemberItemID_MemberItems { get; set; }
+        public string MemberID_MemberItems { get; set; }
+        public string ItemListID_MemberItems { get; set; }
+        public string ItemCount_MemberItems { get; set; }
+        public string ItemStatus_MemberItems { get; set; }
+        public string sCol1_MemberItems { get; set; }
+        public string sCol2_MemberItems { get; set; }
+        public string sCol3_MemberItems { get; set; }
+        public string sCol4_MemberItems { get; set; }
+        public string sCol5_MemberItems { get; set; }
+        public string sCol6_MemberItems { get; set; }
+        public string sCol7_MemberItems { get; set; }
+        public string sCol8_MemberItems { get; set; }
+        public string sCol9_MemberItems { get; set; }
+        public string sCol10_MemberItems { get; set; }
+        public string eventID_GameEventMember { get; set; }
+        public string MemberID_GameEventMember { get; set; }
+        public string sCol1_GameEventMember { get; set; }
+        public string sCol2_GameEventMember { get; set; }
+        public string sCol3_GameEventMember { get; set; }
+        public string sCol4_GameEventMember { get; set; }
+        public string sCol5_GameEventMember { get; set; }
+        public string sCol6_GameEventMember { get; set; }
+        public string sCol7_GameEventMember { get; set; }
+        public string sCol8_GameEventMember { get; set; }
+        public string sCol9_GameEventMember { get; set; }
+        public string sCol10_GameEventMember { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/UdtMemberGameInfoStage.cs
+++ b/Models/UdtMemberGameInfoStage.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class UdtMemberGameInfoStageInputParams
+    {
+        public string InsertORUpdate { get; set; }
+        public string MemberID_MemberGameInfoes { get; set; }
+        public string Level_MemberGameInfoes { get; set; }
+        public string Exps_MemberGameInfoes { get; set; }
+        public string Points_MemberGameInfoes { get; set; }
+        public string UserSTAT1_MemberGameInfoes { get; set; }
+        public string UserSTAT2_MemberGameInfoes { get; set; }
+        public string UserSTAT3_MemberGameInfoes { get; set; }
+        public string UserSTAT4_MemberGameInfoes { get; set; }
+        public string UserSTAT5_MemberGameInfoes { get; set; }
+        public string UserSTAT6_MemberGameInfoes { get; set; }
+        public string UserSTAT7_MemberGameInfoes { get; set; }
+        public string UserSTAT8_MemberGameInfoes { get; set; }
+        public string UserSTAT9_MemberGameInfoes { get; set; }
+        public string UserSTAT10_MemberGameInfoes { get; set; }
+        public string sCol1_MemberGameInfoes { get; set; }
+        public string sCol2_MemberGameInfoes { get; set; }
+        public string sCol3_MemberGameInfoes { get; set; }
+        public string sCol4_MemberGameInfoes { get; set; }
+        public string sCol5_MemberGameInfoes { get; set; }
+        public string sCol6_MemberGameInfoes { get; set; }
+        public string sCol7_MemberGameInfoes { get; set; }
+        public string sCol8_MemberGameInfoes { get; set; }
+        public string sCol9_MemberGameInfoes { get; set; }
+        public string sCol10_MemberGameInfoes { get; set; }
+        public string MemberGameInfoStageID_MemberGameInfoStages { get; set; }
+        public string MemberID_MemberGameInfoStages { get; set; }
+        public string StageName_MemberGameInfoStages { get; set; }
+        public string StageStatus_MemberGameInfoStages { get; set; }
+        public string Category1_MemberGameInfoStages { get; set; }
+        public string Category2_MemberGameInfoStages { get; set; }
+        public string Category3_MemberGameInfoStages { get; set; }
+        public string Mission1_MemberGameInfoStages { get; set; }
+        public string Mission2_MemberGameInfoStages { get; set; }
+        public string Mission3_MemberGameInfoStages { get; set; }
+        public string Mission4_MemberGameInfoStages { get; set; }
+        public string Mission5_MemberGameInfoStages { get; set; }
+        public string Points_MemberGameInfoStages { get; set; }
+        public string StageStat1_MemberGameInfoStages { get; set; }
+        public string StageStat2_MemberGameInfoStages { get; set; }
+        public string StageStat3_MemberGameInfoStages { get; set; }
+        public string StageStat4_MemberGameInfoStages { get; set; }
+        public string StageStat5_MemberGameInfoStages { get; set; }
+        public string sCol1_MemberGameInfoStages { get; set; }
+        public string sCol2_MemberGameInfoStages { get; set; }
+        public string sCol3_MemberGameInfoStages { get; set; }
+        public string sCol4_MemberGameInfoStages { get; set; }
+        public string sCol5_MemberGameInfoStages { get; set; }
+        public string sCol6_MemberGameInfoStages { get; set; }
+        public string sCol7_MemberGameInfoStages { get; set; }
+        public string sCol8_MemberGameInfoStages { get; set; }
+        public string sCol9_MemberGameInfoStages { get; set; }
+        public string sCol10_MemberGameInfoStages { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/UdtMoveGift.cs
+++ b/Models/UdtMoveGift.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class UdtMoveGiftInputParams
+    {
+        public string InsertORUpdate { get; set; }
+        public string GiftDepositoryID { get; set; }
+        public string MemberItemID { get; set; }
+        public string MemberID { get; set; }
+        public string ItemListID { get; set; }
+        public string ItemCount { get; set; }
+        public string ItemStatus { get; set; }
+        public string sCol1 { get; set; }
+        public string sCol2 { get; set; }
+        public string sCol3 { get; set; }
+        public string sCol4 { get; set; }
+        public string sCol5 { get; set; }
+        public string sCol6 { get; set; }
+        public string sCol7 { get; set; }
+        public string sCol8 { get; set; }
+        public string sCol9 { get; set; }
+        public string sCol10 { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/UdtReturnItem.cs
+++ b/Models/UdtReturnItem.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class UdtReturnItemInputParams
+    {
+        public string DeleteORUpdate { get; set; }
+        public string MemberItemID_MemberItems { get; set; }
+        public string MemberID_MemberItems { get; set; }
+        public string ItemListID_MemberItems { get; set; }
+        public string ItemCount_MemberItems { get; set; }
+        public string ItemStatus_MemberItems { get; set; }
+        public string sCol1_MemberItems { get; set; }
+        public string sCol2_MemberItems { get; set; }
+        public string sCol3_MemberItems { get; set; }
+        public string sCol4_MemberItems { get; set; }
+        public string sCol5_MemberItems { get; set; }
+        public string sCol6_MemberItems { get; set; }
+        public string sCol7_MemberItems { get; set; }
+        public string sCol8_MemberItems { get; set; }
+        public string sCol9_MemberItems { get; set; }
+        public string sCol10_MemberItems { get; set; }
+        public string MemberItemPurchaseID_MemberItemPurchases { get; set; }
+        public string MemberID_MemberItemPurchases { get; set; }
+        public string ItemListID_MemberItemPurchases { get; set; }
+        public string PurchaseQuantity_MemberItemPurchases { get; set; }
+        public string PurchasePrice_MemberItemPurchases { get; set; }
+        public string PGinfo1_MemberItemPurchases { get; set; }
+        public string PGinfo2_MemberItemPurchases { get; set; }
+        public string PGinfo3_MemberItemPurchases { get; set; }
+        public string PGinfo4_MemberItemPurchases { get; set; }
+        public string PGinfo5_MemberItemPurchases { get; set; }
+        public string PurchaseDeviceID_MemberItemPurchases { get; set; }
+        public string PurchaseDeviceIPAddress_MemberItemPurchases { get; set; }
+        public string PurchaseDeviceMACAddress_MemberItemPurchases { get; set; }
+        public string PurchaseDT_MemberItemPurchases { get; set; }
+        public string PurchaseCancelYN_MemberItemPurchases { get; set; }
+        public string PurchaseCancelDT_MemberItemPurchases { get; set; }
+        public string PurchaseCancelingStatus_MemberItemPurchases { get; set; }
+        public string PurchaseCancelReturnedAmount_MemberItemPurchases { get; set; }
+        public string PurchaseCancelDeviceID_MemberItemPurchases { get; set; }
+        public string PurchaseCancelDeviceIPAddress_MemberItemPurchases { get; set; }
+        public string PurchaseCancelDeviceMACAddress_MemberItemPurchases { get; set; }
+        public string sCol1_MemberItemPurchases { get; set; }
+        public string sCol2_MemberItemPurchases { get; set; }
+        public string sCol3_MemberItemPurchases { get; set; }
+        public string sCol4_MemberItemPurchases { get; set; }
+        public string sCol5_MemberItemPurchases { get; set; }
+        public string sCol6_MemberItemPurchases { get; set; }
+        public string sCol7_MemberItemPurchases { get; set; }
+        public string sCol8_MemberItemPurchases { get; set; }
+        public string sCol9_MemberItemPurchases { get; set; }
+        public string sCol10_MemberItemPurchases { get; set; }
+        public string MemberID_MemberGameInfoes { get; set; }
+        public string Level_MemberGameInfoes { get; set; }
+        public string Exps_MemberGameInfoes { get; set; }
+        public string Points_MemberGameInfoes { get; set; }
+        public string UserSTAT1_MemberGameInfoes { get; set; }
+        public string UserSTAT2_MemberGameInfoes { get; set; }
+        public string UserSTAT3_MemberGameInfoes { get; set; }
+        public string UserSTAT4_MemberGameInfoes { get; set; }
+        public string UserSTAT5_MemberGameInfoes { get; set; }
+        public string UserSTAT6_MemberGameInfoes { get; set; }
+        public string UserSTAT7_MemberGameInfoes { get; set; }
+        public string UserSTAT8_MemberGameInfoes { get; set; }
+        public string UserSTAT9_MemberGameInfoes { get; set; }
+        public string UserSTAT10_MemberGameInfoes { get; set; }
+        public string sCol1_MemberGameInfoes { get; set; }
+        public string sCol2_MemberGameInfoes { get; set; }
+        public string sCol3_MemberGameInfoes { get; set; }
+        public string sCol4_MemberGameInfoes { get; set; }
+        public string sCol5_MemberGameInfoes { get; set; }
+        public string sCol6_MemberGameInfoes { get; set; }
+        public string sCol7_MemberGameInfoes { get; set; }
+        public string sCol8_MemberGameInfoes { get; set; }
+        public string sCol9_MemberGameInfoes { get; set; }
+        public string sCol10_MemberGameInfoes { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/Models/UdtSendGift.cs
+++ b/Models/UdtSendGift.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace CloudBread.Models
+{
+    public class UdtSendGiftInputParams
+    {
+        public string DeleteORUpdate { get; set; }
+        public string MemberItemID_MemberItem { get; set; }
+        public string MemberID_MemberItem { get; set; }
+        public string ItemListID_MemberItem { get; set; }
+        public string ItemCount_MemberItem { get; set; }
+        public string ItemStatus_MemberItem { get; set; }
+        public string sCol1_MemberItem { get; set; }
+        public string sCol2_MemberItem { get; set; }
+        public string sCol3_MemberItem { get; set; }
+        public string sCol4_MemberItem { get; set; }
+        public string sCol5_MemberItem { get; set; }
+        public string sCol6_MemberItem { get; set; }
+        public string sCol7_MemberItem { get; set; }
+        public string sCol8_MemberItem { get; set; }
+        public string sCol9_MemberItem { get; set; }
+        public string sCol10_MemberItem { get; set; }
+        public string GiftDepositoryID_GiftDepository { get; set; }
+        public string ItemListID_GiftDepository { get; set; }
+        public string ItemCount_GiftDepository { get; set; }
+        public string FromMemberID_GiftDepository { get; set; }
+        public string ToMemberID_GiftDepository { get; set; }
+        public string sCol1_GiftDepository { get; set; }
+        public string sCol2_GiftDepository { get; set; }
+        public string sCol3_GiftDepository { get; set; }
+        public string sCol4_GiftDepository { get; set; }
+        public string sCol5_GiftDepository { get; set; }
+        public string sCol6_GiftDepository { get; set; }
+        public string sCol7_GiftDepository { get; set; }
+        public string sCol8_GiftDepository { get; set; }
+        public string sCol9_GiftDepository { get; set; }
+        public string sCol10_GiftDepository { get; set; }
+        public string token { get; set; }
+    }
+}

--- a/web.config
+++ b/web.config
@@ -18,19 +18,27 @@
     <add name="CloudBreadStorageConString" connectionString="" />
   </connectionStrings>
   <appSettings>
-    <!-- Adding CloudBread configuration - 설정 추가 -->
+    <!-- Encryption configuration. 암호화 설정-->
+    <add key="CloudBreadCryptSetting" value=""></add>
+    <add key="CloudBreadCryptKey" value=""></add>
+    <add key="CloudBreadCryptIV" value=""></add>
+    <!--
     <add key="CloudBreadCryptSetting" value="AES256"></add>
+    <add key="CloudBreadCryptKey" value="1234567890123456"></add>
+    <add key="CloudBreadCryptIV" value="1234567890123456"></add>
+    -->
+    
+    <!-- Save log to setting. ATS|SQL|redis. 로그를 저장할 저장소 선택 -->
     <add key="CloudBreadLoggerSetting" value="ATS"></add>
-
     <!-- This is DB connection retry trial count. DB연결 재시도 수 -->
     <add key="CloudBreadconRetryCount" value="3"></add>
     <!-- This is DB connection retry trial wait second. In production environment, recommend change to 30 to handle throttling condition. DB연결 재시도 대기 시간 초. 프러덕션 환경에서는 스로틀링 핸들을 위해 30으로 설정 권장 -->
     <add key="CloudBreadconRetryFromSeconds" value="5"></add>
 
-    <!-- This key for CloudBread-Socket project JWT token AES encryption. 이 키는 CloudBread-Socket 프로젝트 JWT 토큰 AES 암호화에 사용되는 값 -->
-    <add key="CloudBreadSocketKeyText" value="1234567890123456"></add>
-    <!-- This IV for CloudBread-Socket project JWT token AES encryption. 이 IV는 CloudBread-Socket 프로젝트 JWT 토큰 AES 암호화에 사용되는 값 -->
-    <add key="CloudBreadSocketKeyIV" value="1234567890123456"></add>
+    <!-- TODO - This key for CloudBread-Socket project JWT token AES encryption. 이 키는 CloudBread-Socket 프로젝트 JWT 토큰 AES 암호화에 사용되는 값 -->
+    <!--<add key="CloudBreadSocketKeyText" value="1234567890123456"></add>-->
+    <!-- TODO - This IV for CloudBread-Socket project JWT token AES encryption. 이 IV는 CloudBread-Socket 프로젝트 JWT 토큰 AES 암호화에 사용되는 값 -->
+    <!--<add key="CloudBreadSocketKeyIV" value="1234567890123456"></add>-->
 
     <!-- This key for connect CloudBread-Socket project JWT token save on Redis service. 이 키는 CloudBread-Socket 프로젝트 JWT 토큰을 저장하는 Redis에 연결 할때 사용되는 값 -->
     <add key="CloudBreadSocketRedisServer" value=""></add>


### PR DESCRIPTION
This PR solving issue #39 

Added encryption feature to CloudBread v2
CloudBread v2 does encrypt whole jason param as a "token"

For example, 
CBComSelItemList1 API, 

```
{
  "memberID": "aaa",
  "itemListID": "itemid1"
}
```

These jason request change to 

```
{
    "token": "NAqJwBORSW5j1flhtMWd92ArJXsWBhPQLobmKPn7wZh5Ofs9TXmcWaDkueLfRbchMktKXMGwIv/QJHqclNaIaw=="
}
```

Rearding to the CloudBread encryption config, Response comes as "token", too.
Please, check out camp workthrough papers and Postman collection.
