### PR TITLE
CBComSelMember issue, memberID is changed when using user authentication

### DIFF
--- a/Controllers/CBComSelMemberController.cs
+++ b/Controllers/CBComSelMemberController.cs
@@ -84,10 +84,10 @@ namespace CloudBread.Controllers
 
         public List<Model> Post(InputParams p)
         {
-            // Get the sid or memberID of the current user.
-            var claimsPrincipal = this.User as ClaimsPrincipal;
-            string sid = CBAuth.getMemberID(p.memberID, claimsPrincipal);
-            p.memberID = sid;
+            //// Get the sid or memberID of the current user.
+            //var claimsPrincipal = this.User as ClaimsPrincipal;
+            //string sid = CBAuth.getMemberID(p.memberID, claimsPrincipal);
+            //p.memberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);


### PR DESCRIPTION
CBComSelMember, there is a issue.

When CloudBread use User Authentications, I response always same Member Data about me!. 

I remove code about sid about authenticated user. 
