### PR TITLE
 CBComSelMember issue, memberID is changed when using user authentica…

### DIFF
--- a/Controllers/CBComSelMemberController.cs
+++ b/Controllers/CBComSelMemberController.cs
@@ -54,9 +54,9 @@ namespace CloudBread.Controllers
                 }
             }
 
-            // Get the sid or memberID of the current user.
-            string sid = CBAuth.getMemberID(p.memberID, this.User as ClaimsPrincipal);
-            p.memberID = sid;
+            //// Get the sid or memberID of the current user.
+            //string sid = CBAuth.getMemberID(p.memberID, this.User as ClaimsPrincipal);
+            //p.memberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);


### PR DESCRIPTION
CBComSelMember, there is a issue.

When CloudBread use User Authentications, I response always same Member Data about me!.

I remove code about sid about authenticated user.
