### PR TITLE
Revert " CBComSelMember issue, memberID is changed when using user authentica…"

### DIFF
--- a/Controllers/CBComSelMemberController.cs
+++ b/Controllers/CBComSelMemberController.cs
@@ -54,9 +54,9 @@ namespace CloudBread.Controllers
                 }
             }
 
-            //// Get the sid or memberID of the current user.
-            //string sid = CBAuth.getMemberID(p.memberID, this.User as ClaimsPrincipal);
-            //p.memberID = sid;
+            // Get the sid or memberID of the current user.
+            string sid = CBAuth.getMemberID(p.memberID, this.User as ClaimsPrincipal);
+            p.memberID = sid;
 
             Logging.CBLoggers logMessage = new Logging.CBLoggers();
             string jsonParam = JsonConvert.SerializeObject(p);


### PR DESCRIPTION
Reverts CloudBreadProject/CloudBread#53

this is comprehensive logic for authentication environemnt.
after member log on to id provider, CloudBread parse http header x-zumo-auth and get the provided id.
